### PR TITLE
Update translations - de.json

### DIFF
--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -193,6 +193,9 @@
     "number": {
       "battery_charging_limit": {
         "name": "Batterieladelimit"
+      },
+      "refresh_interval": {
+        "name": "Aktualisierungsintervall"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -90,7 +90,7 @@
           "901": "Fahrzeug schläft",
           "903": "Weitergeleitet",
           "0": "Abgeschlossen",
-          "300": "Zurückgestellt",
+          "300": "Abgebrochen",
           "500": "Fehler"
         }
       },


### PR DESCRIPTION
Just 2 small changed as it seems to be a better fit to actual meaning.
- "Zurückgestellt" is hinting some sort of queueing. However as per my understanding the request got cancelled and therefor the request won't be processed later. So IMHO "Abgebrochen" seems to be a better fit.
- adding "refresh_interval" as we call it "Aktualisierungsintervall"