### PR TITLE
Just a small fix in StellantisVehicleCoordinator

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -63,7 +63,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
 
     @property
     def vehicle_type(self):
-        return self._stellantis.get_config("type")
+        return self._vehicle["type"]
 
     @property
     def command_history(self):


### PR DESCRIPTION
IMHO it's better to use self._vehicle["type"] :-)