### PR TITLE
Fix #118 - MQTT is not reconnecting after a network outage

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -408,17 +408,19 @@ class StellantisVehicles(StellantisBase):
 
     async def connect_mqtt(self):
         _LOGGER.debug("---------- START connect_mqtt")
+        await self.refresh_mqtt_token()
         if not self._mqtt:
-            await self.refresh_tokens()
             self._mqtt = mqtt.Client(clean_session=True, protocol=mqtt.MQTTv311)
             self._mqtt.enable_logger(logger=_LOGGER)
             self._mqtt.tls_set_context(_SSL_CONTEXT)
             self._mqtt.on_connect = self._on_mqtt_connect
             self._mqtt.on_disconnect = self._on_mqtt_disconnect
             self._mqtt.on_message = self._on_mqtt_message
-            self._mqtt.username_pw_set("IMA_OAUTH_ACCESS_TOKEN", self.get_config("mqtt")["access_token"])
-            self._mqtt.connect(MQTT_SERVER, 8885, 60)
-            self._mqtt.loop_start()
+        if self._mqtt.is_connected():
+            self._mqtt.disconnect()
+        self._mqtt.username_pw_set("IMA_OAUTH_ACCESS_TOKEN", self.get_config("mqtt")["access_token"])
+        self._mqtt.connect(MQTT_SERVER, 8885, 60)
+        self._mqtt.loop_start() # Under the hood, this will call loop_forever in a thread, which means that the thread will terminate if we call disconnect()
         _LOGGER.debug("---------- END connect_mqtt")
         return self._mqtt.is_connected()
 
@@ -484,6 +486,7 @@ class StellantisVehicles(StellantisBase):
 
     async def send_mqtt_message(self, service, message, store=True):
         _LOGGER.debug("---------- START send_mqtt_message")
+        #TODO: check/confirm if a mqtt refresh_token is really needed here
         await self.refresh_tokens(force=(store == False))
         customer_id = self.get_config("customer_id")
         topic = MQTT_REQ_TOPIC + customer_id + service


### PR DESCRIPTION
This PR should fix issue #118
It was only briefly tested in my devcontainer. So some more testing might be needed!

It appears that there was a bug in self.connect_mqtt in terms of how loop_start() and disconnect() plays together.
Check paho-mqtt documentation at https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html for more details.

During the network outage paho-mqtt got disconnected with [error-code 16](https://eclipse.dev/paho/files/paho.mqtt.python/html/types.html#paho.mqtt.enums.MQTTErrorCode):
(Client or broker did not communicate in the keepalive interval.)
```
[36m2025-03-27 19:10:35.432 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] ---------- START _on_mqtt_disconnect[0m
[36m2025-03-27 19:10:35.432 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Code 16 (Client or broker did not communicate in the keepalive interval.)[0m
[36m2025-03-27 19:10:35.432 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Disconnect and reconnect[0m
[36m2025-03-27 19:10:35.434 DEBUG (MainThread) [custom_components.stellantis_vehicles.stellantis] ---------- START connect_mqtt[0m
[36m2025-03-27 19:10:35.435 DEBUG (MainThread) [custom_components.stellantis_vehicles.stellantis] ---------- END connect_mqtt[0m
[36m2025-03-27 19:10:35.435 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] ---------- END _on_mqtt_disconnect[0m

[36m2025-03-27 19:10:35.435 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] ---------- START _on_mqtt_disconnect[0m
[36m2025-03-27 19:10:35.435 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Code 0 (No error.)[0m
[36m2025-03-27 19:10:35.435 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Disconnect and reconnect[0m
[36m2025-03-27 19:10:35.436 DEBUG (MainThread) [custom_components.stellantis_vehicles.stellantis] ---------- START connect_mqtt[0m
[36m2025-03-27 19:10:35.437 DEBUG (MainThread) [custom_components.stellantis_vehicles.stellantis] ---------- END connect_mqtt[0m
[36m2025-03-27 19:10:35.438 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] ---------- END _on_mqtt_disconnect[0m
```

Because [loop_forever()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.loop_forever) will handle reconnecting for us if reconnect_on_failure is true (this is the default behavior). And because [loop_start()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.loop_start), under the hood, calls loop_forever in a thread, paho-mqtt started reconnecting (thats why we see a 2nd attempt to reconnect) and triggered our self._on_mqtt_disconnect() callback.

self._on_mqtt_disconnect() calls [disconnect()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.disconnect) and self.connect_mqtt() for [result-code](https://eclipse.dev/paho/files/paho.mqtt.python/html/types.html#paho.mqtt.enums.MQTTErrorCode) != 1

However [loop_forever()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.loop_forever) will handle reconnecting for us as long as reconnect_on_failure is true (this is the default behavior). If we call [disconnect()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.disconnect) in a callback it will return. And because loop_start() under the hood, calls [loop_forever()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.loop_forever) in a thread, which means that the thread will terminate if we call [disconnect()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.disconnect).

At this point in time we no longer maintain a mqtt network loop (aka [loop_forever](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.loop_forever)). And because [connect()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.connect) got stuck as the connection status will not be updated until a CONNACK is received and processed (this requires a running network loop) and because self.connect_mqtt() only calls [loop_start()](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.loop_start) if self._mqtt is not None it was a dead end.