### PR TITLE
FIX Charging threshold not always applied

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -223,7 +223,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                             button_name = self.get_translation("component.stellantis_vehicles.entity.button.charge_start_stop.name")
                             await self.send_charge_command(button_name)
                             self._manage_charge_limit_sent = True
-                elif self._sensors["battery_charging"] != "InProgress" and not self._manage_charge_limit_sent:
+                elif self._sensors["battery_charging"] != "InProgress" and self._manage_charge_limit_sent:
                     self._manage_charge_limit_sent = False
 
             if "switch_abrp_sync" in self._sensors and self._sensors["switch_abrp_sync"] and "text_abrp_token" in self._sensors and len(self._sensors["text_abrp_token"]) == 36:


### PR DESCRIPTION
This PR is a possible fix for #125 - commit is not yet tested (hence for dev-branch)

Once self._manage_charge_limit_sent is set to "true," it will not be reset to "false." This may result in the charge limit not being applied anymore. From the code it seems the idea is to avoid sending multiple charge_start_stop commands for the same charging session by setting self._manage_charge_limit_sent to "true" and to reset it back to "false" once charging is not "InProgress" anymore.