### PR TITLE
fix raise condition, and leave the reconnection up to paho-mqtt. (discussed in #132)

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -437,13 +437,9 @@ class StellantisVehicles(StellantisBase):
 
     def _on_mqtt_disconnect(self, client, userdata, result_code):
         _LOGGER.debug("---------- START _on_mqtt_disconnect")
-        _LOGGER.debug("Code %s (%s)", result_code, mqtt.error_string(result_code))
+        _LOGGER.debug(f"mqtt disconnected with result code {result_code} -> {mqtt.error_string(result_code)}")
         if result_code == 1:
             self.do_async(self.refresh_mqtt_token(force=True))
-        else:
-            _LOGGER.debug("Disconnect and reconnect")
-            self._mqtt.disconnect()
-            self.do_async(self.connect_mqtt())
         _LOGGER.debug("---------- END _on_mqtt_disconnect")
 
     def _on_mqtt_message(self, client, userdata, msg):


### PR DESCRIPTION
This PR implement the preferred option as discussed in #132
Tested and works fine - debug log of testing below.

```
2025-04-10 14:41:14.370 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Sending PINGREQ
2025-04-10 14:41:14.393 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Received PINGRESP
2025-04-10 14:42:14.464 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Sending PINGREQ
2025-04-10 14:42:44.414 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] ---------- START _on_mqtt_disconnect
2025-04-10 14:42:44.414 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] mqtt disconnected with result code 7 -> The connection was lost.
2025-04-10 14:42:44.414 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] ---------- END _on_mqtt_disconnect
2025-04-10 14:43:05.444 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Connection failed, retrying
2025-04-10 14:43:27.466 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Connection failed, retrying
2025-04-10 14:43:51.489 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Connection failed, retrying
2025-04-10 14:44:16.626 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b''
2025-04-10 14:44:16.819 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Received CONNACK (0, 0)
2025-04-10 14:44:16.819 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] ---------- START _on_mqtt_connect
2025-04-10 14:44:16.819 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Code {'session present': 0}
2025-04-10 14:44:16.820 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Sending SUBSCRIBE (d0, m4) [(b'psa/RemoteServices/to/cid/AC-xxxxxxxxxxx/#', 0)]
2025-04-10 14:44:16.820 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Topic psa/RemoteServices/to/cid/AC-xxxxxxxxxxx/#
2025-04-10 14:44:16.820 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Sending SUBSCRIBE (d0, m5) [(b'psa/RemoteServices/events/MPHRTServices/xxxxxxxxxxx', 0)]
2025-04-10 14:44:16.820 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Topic psa/RemoteServices/events/MPHRTServices/xxxxxxxxxxx
2025-04-10 14:44:16.820 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Sending SUBSCRIBE (d0, m6) [(b'psa/RemoteServices/events/MPHRTServices/xxxxxxxxxxx', 0)]
2025-04-10 14:44:16.821 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Topic psa/RemoteServices/events/MPHRTServices/xxxxxxxxxxx
2025-04-10 14:44:16.821 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] ---------- END _on_mqtt_connect
2025-04-10 14:44:16.843 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Received SUBACK
2025-04-10 14:44:16.864 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Received SUBACK
2025-04-10 14:44:16.866 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Received SUBACK
2025-04-10 14:44:59.940 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Sending PINGREQ
2025-04-10 14:44:59.963 DEBUG (paho-mqtt-client-) [custom_components.stellantis_vehicles.stellantis] Received PINGRESP
```