### PR TITLE
Rework close_session(), verifying an open session exist before closing

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -71,9 +71,7 @@ class StellantisBase:
             self._session = aiohttp.ClientSession()
 
     async def close_session(self):
-        if not self._session:
-            return
-        if self._session.closed:
+        if not self._session or self._session.closed:
             return
         await self._session.close()
         self._session = None

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -71,6 +71,10 @@ class StellantisBase:
             self._session = aiohttp.ClientSession()
 
     async def close_session(self):
+        if not self._session:
+            return
+        if self._session.closed:
+            return
         await self._session.close()
         self._session = None
 


### PR DESCRIPTION
I noticed that in some cases the code threw an exception for non-existent sessions