### PR TITLE
Refresh_mqtt_token() revised, otp.bin file used to get new mqtt refresh_token

### DIFF
--- a/custom_components/stellantis_vehicles/otp/otp.py
+++ b/custom_components/stellantis_vehicles/otp/otp.py
@@ -15,7 +15,7 @@ from . import oaep
 from .load import IWData
 
 # pylint: disable=invalid-name
-CONFIG_NAME = "otp.bin"
+OTP_FILE_NAME = "otp.bin"
 TIMEOUT_IN_S = 10
 
 logger = logging.getLogger(__name__)
@@ -126,7 +126,7 @@ class Otp:
 
         R0 = self.challenge + ";" + iw + ";" + self.get_serial()
         R1 = self.challenge + ";" + iw + ";" + self.data.iwK1
-        logger.debug("%s\n%s\n%s", R0, R1, R2)
+        #logger.debug("%s\n%s\n%s", R0, R1, R2)
         return {"R0": hashlib.sha256(R0.encode("utf-8")).hexdigest(),
                 "R1": hashlib.sha256(R1.encode("utf-8")).hexdigest(),
                 "R2": hashlib.sha256(R2.encode("utf-8")).hexdigest()}
@@ -149,7 +149,7 @@ class Otp:
             mini = x * 128
             ciphertext = cipher.decrypt(enc_b[mini:maxi])
             dec_string += ciphertext.hex()
-        logger.debug(dec_string)
+        #logger.debug(dec_string)
         return dec_string
 
     def request(self, param, setup=False):
@@ -303,7 +303,7 @@ def encode_oeap(text, key):
     return cipher.encrypt(text)
 
 
-def save_otp(obj, filename="otp.bin"):
+def save_otp(obj, filename=OTP_FILE_NAME):
     with open(filename, 'wb') as output:
         pickle.dump(obj, output)
 
@@ -314,7 +314,7 @@ class RenameUnpickler(pickle.Unpickler):
         return super().find_class(renamed_module, name)
 
 
-def load_otp(filename=CONFIG_NAME):
+def load_otp(filename=OTP_FILE_NAME):
     try:
         with open(filename, 'rb') as input_file:
             try:


### PR DESCRIPTION
This is another measure to resolve the error {'error_description': 'grant is invalid', 'error': 'invalid_grant'}, which is usually caused by an expired MQTT refresh token. Unlike the token refresh for the https-based API, the API does not provide a new MQTT refresh token when refreshing an access token.

In addition (and as described at https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/114#issuecomment-2823821063), the MQTT API requires the PIN code to be entered every 7 days.

To work around this, we store the OTP status in an otp.bin file during the initial authentication and reuse it later (currently every 3 days) to request a new MQTT refresh token. Similar to how [psa_car_controller](https://github.com/flobz/psa_car_controller) is doing it.

**It's expected that authentication will be required almost immediately after the update, as the required otp.bin file needs to be created, and therefore authentication is required. Hopefully, this will be the last re-authentication for a long time.**

As usual, this PR has been tested on my HA instance and works for me, but further testing may be required.
@andreadegiovine: if possible can you please put this into a dedicated beta-release?