### PR TITLE
Rework refresh_token logic (refresh_token needs be called earlier)

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -47,6 +47,8 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         _LOGGER.debug("---------- START _async_update_data")
         try:
+            # Update token
+            await self._stellantis.refresh_token()
             # Vehicle status
             self._data = await self._stellantis.get_vehicle_status(self._vehicle)
         except ConfigEntryAuthFailed as e:

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -125,6 +125,7 @@ class StellantisBase:
         return self.replace_placeholders(f"{url}?{query_params}", vehicle)
 
     async def make_http_request(self, url, method='GET', headers=None, params=None, json=None, data=None):
+        _LOGGER.debug("---------- START make_http_request")
         self.start_session()
         try:
             async with self._session.request(method, url, params=params, json=json, data=data, headers=headers) as resp:
@@ -154,6 +155,7 @@ class StellantisBase:
                     await self.close_session()
                     # Generic error
                     raise Exception(error)
+                _LOGGER.debug("---------- END make_http_request")
                 return result
         except ConfigEntryAuthFailed as e:
             _LOGGER.error("Authentication failed during HTTP request: %s", e)
@@ -315,14 +317,6 @@ class StellantisVehicles(StellantisOauth):
             im = ImageOps.pad(im, (400, 400))
         im.save(new_image_path)
         return new_image_url
-
-    async def make_http_request(self, url, method = 'GET', headers = None, params = None, json = None, data = None):
-        _LOGGER.debug("---------- START make_http_request")
-        if method == "GET":
-            await self.refresh_token()
-        result = await super(StellantisVehicles, self).make_http_request(url, method, headers, params, json, data)
-        _LOGGER.debug("---------- END make_http_request")
-        return result
 
     async def refresh_token(self):
         _LOGGER.debug("---------- START refresh_token")


### PR DESCRIPTION
I noticed that the 401 error might be caused by an expired access token (used as a bearer token in the authorization header). Since ```refresh_token``` in ```make_http_request``` is called before the actual HTTP request, but after we apply the query parameters and headers, the integration might run into a situation where the token is refreshed but only used in the next HTTP request and not applied in the current HTTP request. In my opinion, the best solution is to move the ```refresh_token``` calls to ```StellantisVehicleCoordinator _async_update_data```, just before ```get_vehicle_status```, as this ensures it is called at the beginning of each update interval for each vehicle.
This PR is tested on my HA system and works for me. However, might need more testing, so it would be good if you could make another pre-release.