### PR TITLE
Add persistent notification for no vehicles found

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -40,6 +40,10 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
     if vehicles:
         await hass.config_entries.async_forward_entry_setups(config, PLATFORMS)
         await stellantis.connect_mqtt()
+    else:
+        _LOGGER.error("No vehicles found for this account")
+        await stellantis.create_persistent_notification("notification_no_vehicles_found")
+        await stellantis.close_session()
 
     return True
 

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -253,6 +253,18 @@ class StellantisOauth(StellantisBase):
         _LOGGER.debug("---------- END get_otp_code")
         return otp_code
 
+    async def create_persistent_notification(self, translation_key, title=None, notification_id=DOMAIN):
+        """Create a persistent notification."""
+        translations = await translation.async_get_translations(self._hass, self._hass.config.language, "common", {DOMAIN})
+        message = str(translations.get(f"component.stellantis_vehicles.common.{translation_key}", None))
+        if title is None:
+            title = "Stellantis Vehicles - %s" % self._hass.config_entries.async_get_entry(self._entry.entry_id).title
+        self._hass.components.persistent_notification.async_create(
+            message,
+            title=title,
+            notification_id=notification_id
+        )
+
 
 class StellantisVehicles(StellantisOauth):
     def __init__(self, hass) -> None:

--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -221,5 +221,8 @@
         "name": "ABRP Token"
       }
     }
+  },
+  "common": {
+    "notification_no_vehicles_found": "Für dieses Konto wurden keine Fahrzeuge gefunden"
   }
 }

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -221,5 +221,8 @@
         "name": "ABRP token"
       }
     }
+  },
+  "common": {
+    "notification_no_vehicles_found": "No vehicles found for this account"
   }
 }


### PR DESCRIPTION
This is the first of several PRs that implement persistent notifications for selected events about which the user should be informed. As usual, the PR has been tested on my system and works for me.
@andreadegiovine: Let me know if this is a step in the right direction or if you'd like to see it implemented differently.