### PR TITLE
Add MQTT connection check to button state validation

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -546,7 +546,10 @@ class StellantisBaseButton(StellantisBaseEntity, ButtonEntity):
     @property
     def available(self):
         engine_is_off = "engine" in self._coordinator._sensors and self._coordinator._sensors["engine"] == "Stop"
-        return engine_is_off and (self.name not in self._coordinator._disabled_commands) and not self._coordinator.pending_action
+        button_not_disabled = self.name not in self._coordinator._disabled_commands
+        no_pending_action = not self._coordinator.pending_action
+        mqtt_connected = self._stellantis._mqtt and self._stellantis._mqtt.is_connected()
+        return engine_is_off and button_not_disabled and no_pending_action and mqtt_connected
 
     async def async_press(self):
         raise NotImplementedError


### PR DESCRIPTION
This PR adds an MQTT connection check to the StellantisBaseButton class to ensure that MQTT is actually connected before exposing buttons. This is intended to prevent users from pressing a button while MQTT is not connected, since the button/MQTT command cannot be sent anyway (see #155).

As usual, this PR has been tested on my system and works for me.