### PR TITLE
Implement async_remove_entry to clean up resources on entry removal

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -1,14 +1,19 @@
 import logging
+import shutil
+import os
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry
 
 from .stellantis import StellantisVehicles
 
 from .const import (
     DOMAIN,
-    PLATFORMS
+    PLATFORMS,
+    IMAGE_PATH,
+    OTP_FILE_NAME
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,3 +62,39 @@ async def async_unload_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     stellantis._mqtt.disconnect()
 
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, config: ConfigEntry) -> None:
+    if not hass.config_entries.async_loaded_entries(DOMAIN):
+
+        # Remove stale repairs (if any) - just in case this integration will use
+        # the issue registry in the future
+        issue_registry.async_delete_issue(hass, DOMAIN, DOMAIN)
+
+        # Remove any remaining disabled or ignored entries
+        for _entry in hass.config_entries.async_entries(DOMAIN):
+            hass.async_create_task(hass.config_entries.async_remove(_entry.entry_id))
+
+        # Remove OTP file
+        # Curently just a single file, but might be changed in the future
+        # to allow for multiple OTP files
+        # (e.g. for multiple Stellantis accounts)
+        otp_filename = os.path.join(hass.config.config_dir, OTP_FILE_NAME)
+        if os.path.isfile(otp_filename):
+            _LOGGER.debug(f"Deleting OTP-File: {otp_filename}")
+            os.remove(otp_filename)
+
+        # Remove related vehicle images
+        if "vehicles" in config.data:
+            for vehicle in config.data["vehicles"]:
+                vehicle_image_path = os.path.join(hass.config.config_dir, vehicle["picture"].replace("/local", "www"))
+                if os.path.exists(vehicle_image_path) and os.path.isfile(vehicle_image_path):
+                    _LOGGER.debug(f"Deleting Stellantis Vehicle image: {vehicle_image_path}")
+                    os.remove(vehicle_image_path)
+
+        # Remove Stellantis image folder if empty
+        public_path = os.path.join(hass.config.config_dir, "www")
+        stellantis_path = f"{public_path}/{IMAGE_PATH}"
+        if (os.path.exists(stellantis_path) and os.path.isdir(stellantis_path) and not os.listdir(stellantis_path)):
+            _LOGGER.debug(f"Deleting empty Stellantis image folder: {stellantis_path}")
+            shutil.rmtree(stellantis_path)

--- a/custom_components/stellantis_vehicles/config_flow.py
+++ b/custom_components/stellantis_vehicles/config_flow.py
@@ -130,6 +130,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self.data.update({"customer_id": user_info_request[0]["customer"]})
 
+        self.stellantis.save_config({"customer_id": self.data["customer_id"]})
+
         return await self.async_step_otp()
 
 
@@ -165,7 +167,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_mismatch()
             return self.async_update_reload_and_abort(self._get_reauth_entry(), data_updates=self.data, reload_even_if_entry_is_unchanged=False)
 
-        await self.async_set_unique_id(self.data[FIELD_MOBILE_APP].lower()+str(self.data["access_token"][:5]))
+        await self.async_set_unique_id(str(self.data["customer_id"]))
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title=self.data[FIELD_MOBILE_APP], data=self.data)
 

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -11,7 +11,7 @@ with open(os.path.dirname(os.path.abspath(__file__)) + "/configs.json", "r") as 
     MOBILE_APPS = json.load(f)
 
 MQTT_REFRESH_TOKEN_TTL = (60*24*3) # 3 days
-OTP_FILE_NAME = ".storage/" + DOMAIN + "_otp.pickle"
+OTP_FILENAME = "{#customer_id#}_otp.pickle"
 
 IMAGE_PATH = "stellantis-vehicles"
 

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -13,6 +13,8 @@ with open(os.path.dirname(os.path.abspath(__file__)) + "/configs.json", "r") as 
 MQTT_REFRESH_TOKEN_TTL = (60*24*3) # 3 days
 OTP_FILE_NAME = ".storage/" + DOMAIN + "_otp.pickle"
 
+IMAGE_PATH = "stellantis-vehicles"
+
 OAUTH_BASE_URL = "{#oauth_url#}/am/oauth2"
 OAUTH_AUTHORIZE_URL = OAUTH_BASE_URL + "/authorize"
 OAUTH_TOKEN_URL = OAUTH_BASE_URL + "/access_token"

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -240,7 +240,7 @@ class StellantisOauth(StellantisBase):
         storage_path = os.path.join(hass_config_path, ".storage", DOMAIN)
         if not os.path.isdir(storage_path):
             os.mkdir(storage_path)
-        # Generate OTP file path from client_id (unique_id=client_id)
+        # Generate OTP file path from customer_id
         otp_file_path = os.path.join(storage_path, OTP_FILENAME)
         otp_file_path = otp_file_path.replace("{#customer_id#}", self.get_config("customer_id"))
         # Check if OTP object is already loaded, if not load it

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -47,7 +47,7 @@ from .const import (
     UPDATE_INTERVAL,
     IMAGE_PATH,
     MQTT_REFRESH_TOKEN_TTL,
-    OTP_FILE_NAME
+    OTP_FILENAME
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -235,20 +235,27 @@ class StellantisOauth(StellantisBase):
 
     async def get_otp_code(self):
         _LOGGER.debug("---------- START get_otp_code")
-        otp_filename = os.path.join(self._hass.config.config_dir, OTP_FILE_NAME)
+        # Check if storage path exists, if not create it
+        hass_config_path = self._hass.config.path()
+        storage_path = os.path.join(hass_config_path, ".storage", DOMAIN)
+        if not os.path.isdir(storage_path):
+            os.mkdir(storage_path)
+        # Generate OTP file path from client_id (unique_id=client_id)
+        otp_file_path = os.path.join(storage_path, OTP_FILENAME)
+        otp_file_path = otp_file_path.replace("{#customer_id#}", self.get_config("customer_id"))
+        # Check if OTP object is already loaded, if not load it
         if not self.otp:
-            # Check if the OTP file exists and load OTP object
-            if not os.path.isfile(otp_filename):
-                _LOGGER.error(f"Error: file '{otp_filename}' not found, please reauthenticate")
-                raise ConfigEntryAuthFailed(f"'{otp_filename}' file not found, please reauthenticate")
-            self.otp = load_otp(otp_filename)
+            if not os.path.isfile(otp_file_path):
+                _LOGGER.error(f"Error: OTP file '{otp_file_path}' not found, please reauthenticate")
+                raise ConfigEntryAuthFailed(f"OTP file not found, please reauthenticate")
+            self.otp = load_otp(otp_file_path)
         # Get the OTP code using OTP object. It seems there is a rate limit of 6 requests per 24h
         otp_code = await self._hass.async_add_executor_job(self.otp.get_otp_code)
         if not otp_code:
             _LOGGER.error("Error: OTP code is empty, please reauthenticate")
             raise ConfigEntryAuthFailed("OTP code is empty, please reauthenticate")
         # Save updated OTP object to file
-        save_otp(self.otp, otp_filename)
+        save_otp(self.otp, otp_file_path)
         _LOGGER.debug("---------- END get_otp_code")
         return otp_code
 
@@ -315,25 +322,33 @@ class StellantisVehicles(StellantisOauth):
 
     async def resize_and_save_picture(self, url, vin):
         public_path = self._hass.config.path("www")
+        customer_id = self.get_config("customer_id")
 
         if not os.path.isdir(public_path):
             _LOGGER.warning("Folder \"www\" not found in configuration folder")
             return url
 
         stellantis_path = f"{public_path}/{IMAGE_PATH}"
-        if not os.path.isdir(stellantis_path):
-            os.mkdir(stellantis_path)
+        entry_path = f"{stellantis_path}/{customer_id}"
+        if not os.path.isdir(entry_path):
+            os.makedirs(entry_path, exist_ok=True)
 
-        new_image_path = f"{stellantis_path}/{vin}.png"
-        new_image_url = f"/local/{IMAGE_PATH}/{vin}.png"
-        if os.path.isfile(new_image_path):
-            return new_image_url
+        image_path = f"{entry_path}/{vin}.png"
+        image_url = image_path.replace(public_path, "/local")
+        # Migrate to new file structure - can be removed in future versions
+        old_image_path = f"{stellantis_path}/{vin}.png"
+        if os.path.isfile(old_image_path):
+            _LOGGER.debug(f"Migrating image file: {old_image_path} -> {image_path}")
+            os.rename(old_image_path, image_path)
+        # END Migrate to new file structure
+        if os.path.isfile(image_path):
+            return image_url
 
         image = await self._hass.async_add_executor_job(urlopen, url)
         with Image.open(image) as im:
             im = ImageOps.pad(im, (400, 400))
-        im.save(new_image_path)
-        return new_image_url
+        im.save(image_path)
+        return image_url
 
     async def refresh_token(self):
         _LOGGER.debug("---------- START refresh_token")

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -45,13 +45,12 @@ from .const import (
     GET_USER_INFO_URL,
     CAR_API_GET_VEHICLE_TRIPS_URL,
     UPDATE_INTERVAL,
+    IMAGE_PATH,
     MQTT_REFRESH_TOKEN_TTL,
     OTP_FILE_NAME
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-IMAGE_PATH = "stellantis-vehicles"
 
 def _create_ssl_context() -> ssl.SSLContext:
     """Create a SSL context for the MQTT connection."""
@@ -387,6 +386,9 @@ class StellantisVehicles(StellantisOauth):
                     _LOGGER.error("No vehicles found in vehicles_request['_embedded']")
             else:
                 _LOGGER.error("No _embedded found in vehicles_request")
+            # Store the vehicles in the config entry
+            self.save_config({"vehicles": self._vehicles})
+            self.update_stored_config("vehicles", self._vehicles)
         _LOGGER.debug("---------- END get_user_vehicles")
         return self._vehicles
 

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -401,9 +401,6 @@ class StellantisVehicles(StellantisOauth):
                     _LOGGER.error("No vehicles found in vehicles_request['_embedded']")
             else:
                 _LOGGER.error("No _embedded found in vehicles_request")
-            # Store the vehicles in the config entry
-            self.save_config({"vehicles": self._vehicles})
-            self.update_stored_config("vehicles", self._vehicles)
         _LOGGER.debug("---------- END get_user_vehicles")
         return self._vehicles
 


### PR DESCRIPTION
This PR implements ```async_remove_entry```. When the user uninstalls this integration, the OTP file, vehicle images, and image folder (if empty) are cleaned up. Obsolete repairs are also removed. Furthermore, OTP files and images are migrated to the new structure. Since the ```customer_id``` is now used as the ```unique_id```, this PR should also enable multiple accounts (not tested).
As usual, this PR has been tested on my HA system and works for me.