### PR TITLE
fix: handle authentication failure by initiating reauth flow in send_command

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -104,13 +104,13 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
     async def send_command(self, name, service, message):
         try:
             action_id = await self._stellantis.send_mqtt_message(service, message, self._vehicle)
+            self._commands_history.update({action_id: {"name": name, "updates": []}})
         except ConfigEntryAuthFailed as e:
             _LOGGER.error("Authentication failed while sending command '%s' to vehicle '%s': %s", name, self._vehicle['vin'], str(e))
-            raise
+            self._stellantis._entry.async_start_reauth(self._hass)
         except Exception as e:
             _LOGGER.error("Failed to send command %s: %s", name, str(e))
             raise
-        self._commands_history.update({action_id: {"name": name, "updates": []}})
 
     async def send_wakeup_command(self, button_name):
         await self.send_command(button_name, "/VehCharge/state", {"action": "state"})


### PR DESCRIPTION
This PR fixes a bug where, in some cases, the ```ConfigEntryAuthFailed``` exception was not handled properly. As a result, the reauth flow was not started and the user was not notified by HA.
As per [HA documentation](https://developers.home-assistant.io/docs/integration_setup_failures/#handling-expired-credentials), ```entry.async_start_reauth()```can also be used as an alternative to starting a reauth flow.
This PR was tested on my HA system and works for me.