### PR TITLE
Ensure that a value of `0` still allows the `updated_at` to be set

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -355,7 +355,7 @@ class StellantisBaseEntity(CoordinatorEntity):
         if value and not isinstance(value, (float, int, str, bool, list)):
             value = None
 
-        if value and updated_at:
+        if value is not None and updated_at:
             self._attr_extra_state_attributes["updated_at"] = updated_at
 
         return value


### PR DESCRIPTION
If `value` would be a `False`-ish value, the `updated_at` field would not be set. This could be for example when the reported temperature is `0` degrees.