### PR TITLE
Fix: use deepcopy for value_map and updated_at_map in StellantisBaseSensor and StellantisBaseBinarySensor

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -423,7 +423,7 @@ class StellantisBaseEntity(CoordinatorEntity):
         value = self.get_value_from_map(value_map)
         if value or (not key in self._coordinator._sensors):
             self._coordinator._sensors[key] = value
-        
+
         if value == None:
             return None
 
@@ -743,7 +743,7 @@ class StellantisBaseTime(StellantisRestoreEntity, TimeEntity):
     def __init__(self, coordinator, description):
         super().__init__(coordinator, description)
         self._sensor_key = f"time_{self._key}"
-        
+
     @property
     def native_value(self):
         """ Native value. """

--- a/custom_components/stellantis_vehicles/binary_sensor.py
+++ b/custom_components/stellantis_vehicles/binary_sensor.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 
 from homeassistant.components.binary_sensor import ( BinarySensorEntity, BinarySensorEntityDescription, BinarySensorDeviceClass )
 from .base import ( StellantisBaseBinarySensor, StellantisBaseEntity )
@@ -31,7 +32,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         icon = default_value.get("icon", None),
                         device_class = default_value.get("device_class", None)
                     )
-                    entities.extend([StellantisBaseBinarySensor(coordinator, description, default_value.get("value_map"), default_value.get("updated_at_map"), default_value.get("on_value", None))])
+                    entities.extend([StellantisBaseBinarySensor(coordinator, description, deepcopy(default_value.get("value_map")), deepcopy(default_value.get("updated_at_map")), default_value.get("on_value", None))])
 
         description = BinarySensorEntityDescription(
             name = "remote_commands",

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -224,7 +224,7 @@ SENSORS_DEFAULT = {
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "value_map" : ["energies", 0, "extension", "fuel", "consumptions", "total"],
         "updated_at_map" : ["energies", 0, "createdAt"],
-         "suggested_display_precision": 2,
+        "suggested_display_precision": 2,
         "engine": [VEHICLE_TYPE_THERMIC, VEHICLE_TYPE_HYBRID]
     },
     "fuel_consumption_instant" : {

--- a/custom_components/stellantis_vehicles/sensor.py
+++ b/custom_components/stellantis_vehicles/sensor.py
@@ -1,6 +1,7 @@
 import logging
 from time import strftime
 from time import gmtime
+from copy import deepcopy
 
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.const import ( UnitOfLength, UnitOfSpeed, UnitOfEnergy, UnitOfVolume )
@@ -40,7 +41,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                         state_class = default_value.get("state_class", None),
                         suggested_display_precision = default_value.get("suggested_display_precision", None)
                     )
-                    entities.extend([StellantisBaseSensor(coordinator, description, default_value.get("value_map"), default_value.get("updated_at_map"), default_value.get("available", None))])
+                    entities.extend([StellantisBaseSensor(coordinator, description, deepcopy(default_value.get("value_map")), deepcopy(default_value.get("updated_at_map")), default_value.get("available", None))])
 
         description = SensorEntityDescription(
             name = "type",


### PR DESCRIPTION
This PR should fix #194. All credit goes to @adonix31

According to the [debugging](https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/194#issuecomment-3007846185) in #194, update_maps_for_hybrid appears to overwrite the _value_map not only for hybrid vehicles, but for all connected vehicles, resulting in the error "[Index out of range](https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/194#top)" for e.g. electric vehicles.

This PR has only been partially tested because I don't have a hybrid vehicle available. However, it works for my electric vehicles.

This PR also includes some minor whitespace cleanups.
