### PR TITLE
Fix: Thermic oil, coolant and air temperatures to include possible co…

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -448,7 +448,14 @@ class StellantisBaseEntity(CoordinatorEntity):
                 value = (float(value) / 1000) + 10
 
         if key in ["coolant_temperature", "oil_temperature", "air_temperature"]:
-            value = float(value) / 10
+            value = float(value)
+
+            # Convert to Celsius if reported in Fahrenheit
+            country = self._coordinator._config.get("country_code", "").upper()
+            fahrenheit_countries = {"US", "BS", "BZ", "KY", "PW", "FM", "MH", "GU", "MP", "AS", "VI", "LR", "MM", "GB"}  # Adjust this list if needed
+
+            if country in fahrenheit_countries:
+                value = (value - 32) * 5.0 / 9.0
 
         if isinstance(value, str):
             value = value.lower()


### PR DESCRIPTION
Fix for issue #211 induced an error in motor temperatures when dividing the value by 10. Checking the data, it is likely that the values are in Fahrenheit. This PR gets the list of countries that use Fahrenheit, assumes that the data from Stellantis server for these countries are returned in Fahrenheit, and converts to Celsius.

We need to confirm if this is true, so users feedback is essential!

@andreadegiovine if this patch is implemented, can you please add a word about feedback in the description?