### PR TITLE
Improve and Correct Finnish Translations

### DIFF
--- a/custom_components/stellantis_vehicles/translations/fi.json
+++ b/custom_components/stellantis_vehicles/translations/fi.json
@@ -39,7 +39,7 @@
   "entity": {
     "sensor": {
       "service_battery_voltage": {
-        "name": "Käynnistysakku"
+        "name": "Käynnistysakun varaustaso"
       },
       "type": {
         "name": "Tyyppi",
@@ -60,16 +60,16 @@
         "name": "Nopeus"
       },
       "autonomy": {
-        "name": "Autolla pääsee"
+        "name": "Toimintamatka sähköllä"
       },
       "battery": {
-        "name": "Ajoakku"
+        "name": "Ajoakun varaustaso"
       },
       "battery_soh": {
-        "name": "Ajoakun SOH"
+        "name": "Ajoakun kunto"
       },
       "battery_charging_rate": {
-        "name": "Ajoakun latausmäärä"
+        "name": "Ajoakun latausnopeus"
       },
       "battery_charging_type": {
         "name": "Lataustapa",
@@ -103,10 +103,10 @@
         }
       },
       "fuel": {
-        "name": "Polttoaine"
+        "name": "Polttoaineen taso"
       },
       "fuel_autonomy": {
-        "name": "Polttoainetta jäljellä"
+        "name": "Toimintamatka polttoaineella"
       },
       "fuel_consumption_total": {
         "name": "Kokonaiskulutus"
@@ -136,16 +136,16 @@
             "name": "Keskinopeus"
           },
           "max_speed": {
-            "name": "Max nopeus"
+            "name": "Enimmäisnopeus"
           },
           "electric_consumption": {
-            "name": "Sähkön kulutus"
+            "name": "Sähkönkulutus"
           },
           "electric_avg_consumption": {
             "name": "Sähkön keskikulutus"
           },
           "fuel_consumption": {
-            "name": "Polttoaineen kulutus"
+            "name": "Polttoaineenkulutus"
           },
           "fuel_avg_consumption": {
             "name": "Polttoaineen keskikulutus"
@@ -229,7 +229,7 @@
         "name": "Latauksen rajoitus päälle"
       },
       "abrp_sync": {
-        "name": "ABRP synkronointi"
+        "name": "ABRP-synkronointi"
       },
       "notifications": {
         "name": "Huomautukset"
@@ -237,7 +237,7 @@
     },
     "text": {
       "abrp_token": {
-        "name": "ABRP token"
+        "name": "ABRP-tunnus"
       }
     },
     "time": {
@@ -249,7 +249,7 @@
   "common": {
     "access_token_error_title": "Tunnistusvirhe",
     "access_token_error_message": "Tarkista ohjeistus [OAuth2 Code](https://github.com/andreadegiovine/homeassistant-stellantis-vehicles?tab=readme-ov-file#oauth2-code) osiosta",
-    "otp_error_title": "OTP virhe",
+    "otp_error_title": "OTP-virhe",
     "otp_error_message": "Tarkista ohjeistus [OTP error - NOK:MAXNBTOOLS](https://github.com/andreadegiovine/homeassistant-stellantis-vehicles?tab=readme-ov-file#otp-error---nokmaxnbtools) osiosta",
     "no_vehicles_found_title": "Ajoneuvo ei saatavissa",
     "no_vehicles_found_message": "Tilissä ei ole yhdistettyjä ajoneuvoja",


### PR DESCRIPTION
### Summary

This pull request updates the Finnish translation file (`fi.json`) to improve linguistic accuracy, clarity, and grammatical correctness.

### Key Changes

* **Increased Precision in Sensor Names**

    Sensor names have been updated to be more descriptive of the data they represent, specifying a level or state where appropriate. Examples:

    -   **Starter battery:** `Käynnistysakku` → `Käynnistysakun varaustaso` (Starter battery's charge level)
    -   **EV battery:** `Ajoakku` → `Ajoakun varaustaso` (EV battery's charge level)
    -   **Fuel:** `Polttoaine` → `Polttoaineen taso` (Fuel level)

* **Semantic and Terminological Corrections**

    Vague or incorrect terms have been replaced with standard Finnish automotive vocabulary to ensure technical accuracy. Examples:

    -   **State of Health (SOH):** Updated to `Ajoakun kunto` (EV battery's condition), which is the idiomatic Finnish term.
    -   **Charging Rate:** Corrected `latausmäärä` (amount) to `latausnopeus` (rate) to accurately describe the sensor's measurement.
    -   **Range:** Standardized the terms for electric and fuel range to `Toimintamatka sähköllä` and `Toimintamatka polttoaineella` for clarity and consistency.

* **Grammatical and Orthographical Fixes**

    Corrected multiple entries to adhere to standard Finnish grammar, particularly regarding compound words and the use of hyphens with acronyms. Examples: 
    - `Sähkön kulutus` → `Sähkönkulutus`
    - `ABRP synkronointi` → `ABRP-synkronointi`.
