### PR TITLE
Improved MQTT connection: added connection check and implemented error handling

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -44,7 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
 
     if vehicles:
         await hass.config_entries.async_forward_entry_setups(config, PLATFORMS)
-        await stellantis.connect_mqtt()
     else:
         _LOGGER.error("No vehicles found for this account")
         await stellantis.hass_notify("no_vehicles_found")


### PR DESCRIPTION
The idea of this PR is to further improve MQTT connection handling. It implements an MQTT connection check in get_vehicle_status() to verify the MQTT connection during the refresh interval. It also implements improved error handling in connect_mqtt() and MQTT token validation in case of an MQTT disconnect event.

This PR has only been briefly tested on my HA system and should therefore be provided as a pre-release version to allow for extensive testing.

@chmtc94: This PR should partially resolve #255. I would appreciate it if you could also test and verify it on our system.