### PR TITLE
Improves MQTT command management: Avoid tracking unsuccessfully sent commands in the command history

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -113,7 +113,8 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         """ Send a command to the vehicle. """
         try:
             action_id = await self._stellantis.send_mqtt_message(service, message, self._vehicle)
-            self._commands_history.update({action_id: {"name": name, "updates": []}})
+            if action_id is not None:
+                self._commands_history.update({action_id: {"name": name, "updates": []}})
         except ConfigEntryAuthFailed as e:
             _LOGGER.error("Authentication failed while sending command '%s' to vehicle '%s': %s", name, self._vehicle['vin'], str(e))
             self._stellantis._entry.async_start_reauth(self._hass)

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -649,7 +649,10 @@ class StellantisVehicles(StellantisOauth):
             })
             _LOGGER.debug(topic)
             _LOGGER.debug(data)
-            self._mqtt.publish(topic, data)
+            message_info = self._mqtt.publish(topic, data)
+            if message_info.rc != mqtt.MQTT_ERR_SUCCESS:
+                _LOGGER.error("Failed to send MQTT message: %s", mqtt.error_string(message_info.rc))
+                action_id = None
             if store:
                 self._mqtt_last_request = [service, message]
             _LOGGER.debug("---------- END send_mqtt_message")


### PR DESCRIPTION
This PR is a continuation of #256 and should completely resolve #255.
It implements improved MQTT command management by avoiding tracking unsuccessfully sent commands in the command history.

This PR was briefly tested on my HA system and works as expected.