### PR TITLE
Added daylight sensor entity

### DIFF
--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -322,5 +322,12 @@ BINARY_SENSORS_DEFAULT = {
         "updated_at_map" : ["privacy", "createdAt"],
         "device_class" : BinarySensorDeviceClass.LOCK,
         "on_value": "None"
+    },
+    "daylight" : {
+        "icon" : "mdi:weather-sunny",
+        "device_class": BinarySensorDeviceClass.LIGHT,
+        "value_map" : ["environment", "luminosity", "day"],
+        "updated_at_map" : ["environment", "luminosity", "createdAt"],
+        "on_value": True
     }
 }

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -180,6 +180,9 @@
       },
       "remote_commands": {
         "name": "Remote commands"
+      },
+      "daylight": {
+        "name": "Daylight"
       }
     },
     "button": {

--- a/custom_components/stellantis_vehicles/translations/no.json
+++ b/custom_components/stellantis_vehicles/translations/no.json
@@ -108,6 +108,9 @@
       },
       "preconditioning": {
         "name": "Klimaanlegg"
+      },
+      "daylight": {
+        "name": "Dagslys"
       }
     },
     "button": {


### PR DESCRIPTION
Added parsing of daylight sensor present in e.g. Opel Mokka state updates:

```
{
  "environment": {
    "luminosity": {
      "createdAt": "2025-08-12T07:06:34Z",
      "day": true
    },
    "air": {
      "createdAt": "2025-08-12T07:06:34Z",
      "temp": 13.5
    }
  },
  ...
}
```