### PR TITLE
fix: avoid blocking call when saving vehicle images

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -366,7 +366,7 @@ class StellantisVehicles(StellantisOauth):
         image = await self._hass.async_add_executor_job(urlopen, url)
         with Image.open(image) as im:
             im = ImageOps.pad(im, (400, 400))
-        im.save(image_path)
+        await self._hass.async_add_executor_job(im.save, image_path)
         return image_url
 
     async def refresh_token(self):


### PR DESCRIPTION
This PR fixes [#268](https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/268)
