### PR TITLE
Match Residual and Capacity value alterations

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -453,8 +453,7 @@ class StellantisBaseEntity(CoordinatorEntity):
             # https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/272
             correction_on = self._coordinator._sensors.get("switch_battery_values_correction", False)
             if value and correction_on:
-                if key == "battery_residual":
-                    value = value * 1.343
+                value = value * 1.343
 
         if key in ["coolant_temperature", "oil_temperature", "air_temperature"]:
             value = float(value)


### PR DESCRIPTION
Match Residual and Capacity value alterations from #272 
<img width="283" height="253" alt="image" src="https://github.com/user-attachments/assets/b81f6df4-d79d-430c-b55d-8f45d517d3bf" />
Currently residual can exceed capacity