### PR TITLE
Update Last Trip - Attribute - Consumption / Consumption per 100km

### DIFF
--- a/custom_components/stellantis_vehicles/sensor.py
+++ b/custom_components/stellantis_vehicles/sensor.py
@@ -132,7 +132,10 @@ class StellantisLastTripSensor(StellantisRestoreSensor):
                 if consuption["type"] == VEHICLE_TYPE_ELECTRIC:
                     consumption_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
                     avg_consumption_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR+"/100"+UnitOfLength.KILOMETERS
-                    divide = 1000
+                    divide = 1000                    
+                    correction_on = self._coordinator._sensors.get("switch_battery_values_correction", False)
+                    if correction_on:
+                        divide = 0.744
                 else:
                     consumption_unit_of_measurement = UnitOfVolume.LITERS
                     avg_consumption_unit_of_measurement = UnitOfVolume.LITERS+"/100"+UnitOfLength.KILOMETERS


### PR DESCRIPTION
Diving by 0.744 to match the 1.343 change made in #272 

@andreadegiovine 
I think this value should actually be 1.341 (i beleive stelantis is reporting in horsepower per hour rather than kwh, and the conversion between the 2 is 1.341, Which would make sense as all old cars were measured in horse power), however have matched what has already been impliented.