### PR TITLE
Update Last Trip - Attribute - Consumption / Consumption per 100km

### DIFF
--- a/custom_components/stellantis_vehicles/sensor.py
+++ b/custom_components/stellantis_vehicles/sensor.py
@@ -133,6 +133,9 @@ class StellantisLastTripSensor(StellantisRestoreSensor):
                     consumption_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
                     avg_consumption_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR+"/100"+UnitOfLength.KILOMETERS
                     divide = 1000
+                    correction_on = self._coordinator._sensors.get("switch_battery_values_correction", False)
+                    if correction_on:
+                        divide = 0.74626
                 else:
                     consumption_unit_of_measurement = UnitOfVolume.LITERS
                     avg_consumption_unit_of_measurement = UnitOfVolume.LITERS+"/100"+UnitOfLength.KILOMETERS


### PR DESCRIPTION
Diving by 0.7462 to match the 1.343 change made in #272 
1000/1.34 = 746.2 as we have already divided by 1000 the modification only needs to be 0.7462 which will, in effect, times the energy reported by 1.343

@andreadegiovine 
I think this value should actually be 1.341 (i beleive stelantis is trying to convert from horsepower per hour to kwh so is dividing by 1.341, Which would make sense as all old cars were measured in horse power), however have matched what has already been impliented.