### PR TITLE
Update Last trip - attributes consumption

### DIFF
--- a/custom_components/stellantis_vehicles/sensor.py
+++ b/custom_components/stellantis_vehicles/sensor.py
@@ -137,7 +137,7 @@ class StellantisLastTripSensor(StellantisRestoreSensor):
                     divide = 1000
                     correction_on = self._coordinator._sensors.get("switch_battery_values_correction", False)
                     if correction_on:
-                        divide = 0.74626
+                        divide = 746.26
                 else:
                     consumption_unit_of_measurement = UnitOfVolume.LITERS
                     avg_consumption_unit_of_measurement = UnitOfVolume.LITERS+"/100"+UnitOfLength.KILOMETERS


### PR DESCRIPTION
Had previously assumed the divide by 1000 would also apply. However this was not the case so incrementing 0.76 by 1000 times to fix
![Screenshot_20250905_213441_Home Assistant](https://github.com/user-attachments/assets/448f690e-da6e-42f6-b377-9dc6ec832ffa)
