### PR TITLE
Battery values correction - Reload fix

### DIFF
--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -88,8 +88,8 @@ PLATFORMS = [
     "button",
     "device_tracker",
     "number",
-    "sensor",
     "switch",
+    "sensor",
     "text",
     "time"
 ]


### PR DESCRIPTION
Update const.py to load switches before sensors to support the KWH_Calculation

Changing the load order has fixed the issue mentioned in #296 and #289 

Is there a list of checks we can do to ensure it hasnt effected any other logic?