### PR TITLE
fix: set rate limit duration for send_wakeup_command to 1200

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -131,7 +131,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Failed to send command %s: %s", name, str(e))
             raise
 
-    @rate_limit(6, 120) # 6 per 20 min
+    @rate_limit(6, 1200) # 6 per 20 min
     async def send_wakeup_command(self, button_name):
         """ Send wakeup command to the vehicle. """
         await self.send_command(button_name, "/VehCharge/state", {"action": "state"})


### PR DESCRIPTION
Assuming it's indeed supposed to be 20 minutes (as the comment and the translations indicate), this should be `1200` seconds, instead of just `120` :)