### PR TITLE
Update German translations regarding privacy, charging and preconditioning

### DIFF
--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -154,6 +154,53 @@
             "name": "Durchschnittlicher Kraftstoffverbrauch"
           }
         }
+      },
+      "last_charge": {
+        "name": "Letzte Ladung",
+        "state_attributes": {
+          "in_progress": {
+            "name": "Wird geladen",
+            "state": {
+              "true": "Yes"
+            }
+          },
+            "initial_percentage": {
+            "name": "Anfänglicher Ladezustand"
+          },
+            "initial_energy": {
+            "name": "Anfängliche Energiemenge"
+          },
+            "initial_autonomy": {
+            "name": "Anfängliche Reichweite"
+          },
+            "final_time": {
+            "name": "Endzeit"
+          },
+            "final_percentage": {
+            "name": "Finaler Ladezustand"
+          },
+            "final_energy": {
+            "name": "Finaler Energieinhalt"
+          },
+            "final_autonomy": {
+            "name": "Finale Reichweite"
+          },
+            "duration": {
+            "name": "Dauer des Ladevorgangs"
+          },
+            "recharged_percent": {
+            "name": "Aufgeladene Energie in Prozent"
+          },
+            "recharged_energy": {
+            "name": "Aufgeladene Energiemenge"
+          },
+            "recharged_autonomy": {
+            "name": "Aufgeladene Reichweite"
+          },
+          "avg_power": {
+            "name": "Durchschnittliche Ladeleistung"
+          }
+        }
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
This is just a small PR to suggest an (in my opinion) improved German translation.
(Inspired by: https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/297#issuecomment-3284475631)

Edit: Since I was working on it, I also added German translations for the 'last_charge' attributes :-)
(what is the purpose of ``` "state": { "true": "Yes" }``` in 'last_charge' ?)