### PR TITLE
Feature implementation - track charge cost and real-world consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [OAuth2 Code](#oauth2-code)
 - [Commands](#commands)
 - [Battery capacity / residual sensors](#battery-capacity--residual-sensors)
+- [Charge cost / actual consumption](#charge-cost--actual-consumption)
 - [Card: Stellantis Vehicles](#card-stellantis-vehicles)
 - [Global preferences](#global-preferences)
 - [Errors](#errors)
@@ -171,6 +172,18 @@ As described in the Stellantis apps, the command is enabled when:
 Thanks to the community ([#272](https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/272)), it seems that for some vehicles **Stellantis provides incorrect values**. The **switch.battery_values_correction** entity (in your language) applies a correction if active.
 
 \*currently only to the battery_residual sensor
+
+## Charge cost / actual consumption
+Charge-capable vehicles now expose:
+- **number.kwh_cost** to set your per-vehicle electricity tariff
+- **sensor.charge_cost** for the latest completed charge cost
+- **sensor.actual_average_consumption** for the real-world efficiency since the previous completed charge, in `kWh/100km`
+
+The existing **sensor.last_charge** entity also includes charge cost, mileage, distance since last charge, and actual average consumption in its attributes.
+
+Charge cost stays unavailable until you set **number.kwh_cost** to a value greater than `0`.
+
+The first valid **sensor.actual_average_consumption** value requires **two completed charges recorded by this version**, because it uses the distance driven between charge sessions.
 
 ## Card: Stellantis Vehicles
 A new custom card is available to manage the vehicle, the card is configurable from the visual editor or via yaml:

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -3,6 +3,7 @@ import re
 from datetime import datetime, timedelta, UTC
 import json
 from copy import deepcopy
+from time import ( strftime, gmtime )
 
 from homeassistant.helpers.update_coordinator import ( CoordinatorEntity, DataUpdateCoordinator )
 from homeassistant.components.device_tracker import ( SourceType, TrackerEntity )
@@ -47,6 +48,10 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         self._last_trip = None
 #        self._total_trip = None
         self._manage_charge_limit_sent = False
+        self._last_charge_state = {"native_value": None, "attributes": {}}
+        self._charge_wait_next_update = False
+        self._charge_tracking_run_id = 0
+        self._charge_tracking_last_run_id = None
 
         if self._stellantis.logger_filter:
             _LOGGER.addFilter(self._stellantis.logger_filter)
@@ -64,6 +69,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         except Exception:
             pass
         await self.after_async_update_data()
+        self._charge_tracking_run_id = self._charge_tracking_run_id + 1
         _LOGGER.debug("---------- END _async_update_data")
 
     def get_translation(self, path, default = None):
@@ -74,6 +80,11 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
     def vehicle_type(self):
         """ Vehicle type. """
         return self._vehicle["type"]
+
+    @property
+    def currency_code(self):
+        """ Home Assistant currency code. """
+        return str(getattr(self._hass.config, "currency", "") or "")
 
     @property
     def command_history(self):
@@ -275,6 +286,238 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                     self._last_trip = trips["_embedded"]["trips"][-1]
         except Exception:
             pass
+
+    @staticmethod
+    def _float_or_none(value):
+        """ Convert value to float if possible. """
+        if value is None or value == "":
+            return None
+        if isinstance(value, bool):
+            return float(value)
+        if isinstance(value, (int, float)):
+            return float(value)
+        try:
+            return float(str(value).strip())
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _datetime_or_none(value):
+        """ Convert value to timezone-aware datetime if possible. """
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return get_datetime(value)
+        try:
+            return get_datetime(datetime.fromisoformat(str(value)))
+        except (TypeError, ValueError):
+            return None
+
+    def get_vehicle_config_value(self, key, default = None):
+        """ Get per-vehicle stored config with sensor cache fallback. """
+        vin = self._vehicle["vin"]
+        value = self._stellantis.get_vehicle_stored_config(vin, key)
+        if value is None:
+            value = self._sensors.get(key, default)
+        if value is None:
+            return default
+        return value
+
+    def set_last_charge_state(self, native_value, attributes = None):
+        """ Store the current last charge session state. """
+        if attributes is None:
+            attributes = {}
+        self._last_charge_state = {
+            "native_value": native_value,
+            "attributes": deepcopy(attributes)
+        }
+        self._charge_tracking_last_run_id = None
+
+    def get_last_charge_state(self):
+        """ Get the current last charge session state. """
+        return {
+            "native_value": self._last_charge_state.get("native_value"),
+            "attributes": deepcopy(self._last_charge_state.get("attributes", {}))
+        }
+
+    def _get_corrected_energy_from_raw(self, raw_value):
+        """ Convert raw battery residual value to kWh. """
+        value = self._float_or_none(raw_value)
+        if value is None or value < 1:
+            return None
+
+        divide = 1000
+        correction_on = self._sensors.get("switch_battery_values_correction", False)
+        if correction_on:
+            divide = divide / KWH_CORRECTION
+
+        return round(value / divide, 2)
+
+    def _update_charge_metrics(self, attributes):
+        """ Recalculate charge-derived metrics from the stored session data. """
+        raw_initial_energy = self.get_vehicle_config_value("last_charge_initial_energy_raw")
+        raw_final_energy = self.get_vehicle_config_value("last_charge_final_energy_raw")
+
+        initial_energy = self._get_corrected_energy_from_raw(raw_initial_energy)
+        final_energy = self._get_corrected_energy_from_raw(raw_final_energy)
+
+        if initial_energy is not None:
+            attributes["initial_energy"] = initial_energy
+        else:
+            attributes.pop("initial_energy", None)
+
+        if final_energy is not None:
+            attributes["final_energy"] = final_energy
+        else:
+            attributes.pop("final_energy", None)
+
+        if initial_energy is not None and final_energy is not None:
+            recharged_energy = round(final_energy - initial_energy, 2)
+            attributes["recharged_energy"] = recharged_energy
+
+            started_at = self._datetime_or_none(self._last_charge_state.get("native_value"))
+            final_time = self._datetime_or_none(attributes.get("final_time"))
+            if started_at and final_time:
+                duration = final_time - started_at
+                duration_hours = duration.total_seconds() / 3600
+                if duration_hours > 0:
+                    attributes["avg_power"] = round(recharged_energy / duration_hours, 2)
+                else:
+                    attributes.pop("avg_power", None)
+        else:
+            attributes.pop("recharged_energy", None)
+            attributes.pop("avg_power", None)
+
+        kwh_cost = self._float_or_none(self.get_vehicle_config_value("number_kwh_cost", 0))
+        recharged_energy = self._float_or_none(attributes.get("recharged_energy"))
+        if kwh_cost is not None and kwh_cost > 0 and recharged_energy is not None and recharged_energy > 0:
+            attributes["charge_cost"] = round(recharged_energy * kwh_cost, 2)
+        else:
+            attributes.pop("charge_cost", None)
+
+        distance_since_last_charge = self._float_or_none(attributes.get("distance_since_last_charge"))
+        if recharged_energy is not None and recharged_energy > 0 and distance_since_last_charge is not None and distance_since_last_charge > 0:
+            attributes["actual_average_consumption"] = round((recharged_energy / distance_since_last_charge) * 100, 2)
+        else:
+            attributes.pop("actual_average_consumption", None)
+
+        self._sensors["charge_cost"] = attributes.get("charge_cost")
+        self._sensors["actual_average_consumption"] = attributes.get("actual_average_consumption")
+
+        return attributes
+
+    def update_charge_tracking(self, force = False):
+        """ Update the shared last charge state and derived charge metrics. """
+        if not force and self._charge_tracking_last_run_id == self._charge_tracking_run_id:
+            return self.get_last_charge_state()
+
+        native_value = self._last_charge_state.get("native_value")
+        attributes = deepcopy(self._last_charge_state.get("attributes", {}))
+        charging_status = self._sensors.get("battery_charging")
+        in_progress = charging_status == "InProgress"
+        prev_in_progress = bool(attributes.get("in_progress"))
+
+        if charging_status is not None:
+            if in_progress and not prev_in_progress:
+                native_value = get_datetime()
+                attributes["in_progress"] = True
+
+                battery = self._float_or_none(self._sensors.get("battery"))
+                if battery is not None:
+                    attributes["initial_percentage"] = round(battery)
+
+                initial_energy_raw = self._sensors.get("battery_residual")
+                self._stellantis.update_vehicle_stored_config(self._vehicle["vin"], "last_charge_initial_energy_raw", initial_energy_raw)
+                self._stellantis.update_vehicle_stored_config(self._vehicle["vin"], "last_charge_final_energy_raw", None)
+
+                initial_autonomy = self._float_or_none(self._sensors.get("autonomy"))
+                if initial_autonomy is not None:
+                    attributes["initial_autonomy"] = round(initial_autonomy, 2)
+
+                initial_mileage = self._float_or_none(self._sensors.get("mileage"))
+                if initial_mileage is not None:
+                    attributes["initial_mileage"] = round(initial_mileage, 2)
+
+                for key in [
+                    "final_time",
+                    "final_percentage",
+                    "final_energy",
+                    "final_autonomy",
+                    "final_mileage",
+                    "duration",
+                    "recharged_percent",
+                    "recharged_energy",
+                    "recharged_autonomy",
+                    "avg_power",
+                    "distance_since_last_charge",
+                    "charge_cost",
+                    "actual_average_consumption"
+                ]:
+                    attributes.pop(key, None)
+
+                self._charge_wait_next_update = False
+
+            elif prev_in_progress and not in_progress:
+                if self._charge_wait_next_update:
+                    attributes.pop("in_progress", None)
+                    attributes["final_time"] = get_datetime()
+
+                    battery = self._float_or_none(self._sensors.get("battery"))
+                    if battery is not None:
+                        attributes["final_percentage"] = round(battery)
+
+                    final_energy_raw = self._sensors.get("battery_residual")
+                    self._stellantis.update_vehicle_stored_config(self._vehicle["vin"], "last_charge_final_energy_raw", final_energy_raw)
+
+                    final_autonomy = self._float_or_none(self._sensors.get("autonomy"))
+                    if final_autonomy is not None:
+                        attributes["final_autonomy"] = round(final_autonomy, 2)
+
+                    final_mileage = self._float_or_none(self._sensors.get("mileage"))
+                    if final_mileage is not None:
+                        final_mileage = round(final_mileage, 2)
+                        attributes["final_mileage"] = final_mileage
+
+                    started_at = self._datetime_or_none(native_value)
+                    final_time = self._datetime_or_none(attributes.get("final_time"))
+                    if started_at and final_time:
+                        duration = final_time - started_at
+                        attributes["duration"] = strftime("%H:%M:%S", gmtime(duration.total_seconds()))
+
+                    initial_percentage = self._float_or_none(attributes.get("initial_percentage"))
+                    final_percentage = self._float_or_none(attributes.get("final_percentage"))
+                    if initial_percentage is not None and final_percentage is not None:
+                        attributes["recharged_percent"] = round(final_percentage - initial_percentage)
+
+                    initial_autonomy = self._float_or_none(attributes.get("initial_autonomy"))
+                    final_autonomy = self._float_or_none(attributes.get("final_autonomy"))
+                    if initial_autonomy is not None and final_autonomy is not None:
+                        attributes["recharged_autonomy"] = round(final_autonomy - initial_autonomy, 2)
+
+                    previous_final_mileage = self._float_or_none(self.get_vehicle_config_value("last_charge_final_mileage"))
+                    initial_mileage = self._float_or_none(attributes.get("initial_mileage"))
+                    if initial_mileage is not None and previous_final_mileage is not None:
+                        distance_since_last_charge = round(initial_mileage - previous_final_mileage, 2)
+                        if distance_since_last_charge > 0:
+                            attributes["distance_since_last_charge"] = distance_since_last_charge
+                        else:
+                            attributes.pop("distance_since_last_charge", None)
+                    else:
+                        attributes.pop("distance_since_last_charge", None)
+
+                    if final_mileage is not None:
+                        self._stellantis.update_vehicle_stored_config(self._vehicle["vin"], "last_charge_final_mileage", final_mileage)
+
+                    self._charge_wait_next_update = False
+                else:
+                    self._charge_wait_next_update = True
+            else:
+                self._charge_wait_next_update = False
+
+        attributes = self._update_charge_metrics(attributes)
+        self._last_charge_state = {"native_value": native_value, "attributes": attributes}
+        self._charge_tracking_last_run_id = self._charge_tracking_run_id
+        return self.get_last_charge_state()
 
 #     def parse_trips_page_data(self, data):
 #         result = []

--- a/custom_components/stellantis_vehicles/manifest.json
+++ b/custom_components/stellantis_vehicles/manifest.json
@@ -17,5 +17,5 @@
     "pycryptodome==3.*",
     "paho-mqtt>=1.3"
   ],
-  "version": "2026.3.1-beta.1"
+  "version": "2026.3.1-beta.2"
 }

--- a/custom_components/stellantis_vehicles/manifest.json
+++ b/custom_components/stellantis_vehicles/manifest.json
@@ -17,5 +17,5 @@
     "pycryptodome==3.*",
     "paho-mqtt>=1.3"
   ],
-  "version": "2026.3.6"
+  "version": "2026.3.1-beta.1"
 }

--- a/custom_components/stellantis_vehicles/number.py
+++ b/custom_components/stellantis_vehicles/number.py
@@ -1,7 +1,7 @@
 import logging
 
 from homeassistant.core import HomeAssistant
-from homeassistant.const import ( PERCENTAGE, UnitOfTime )
+from homeassistant.const import ( PERCENTAGE, UnitOfTime, UnitOfEnergy )
 from homeassistant.components.number import NumberMode, NumberEntityDescription
 from homeassistant.const import EntityCategory
 
@@ -39,6 +39,19 @@ async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> No
             )
             entities.extend([StellantisBaseNumber(coordinator, description)])
 
+        if coordinator.vehicle_type in [VEHICLE_TYPE_ELECTRIC, VEHICLE_TYPE_HYBRID]:
+            description = NumberEntityDescription(
+                name = "kwh_cost",
+                key = "kwh_cost",
+                translation_key = "kwh_cost",
+                icon = "mdi:cash",
+                native_min_value = 0,
+                native_step = 0.001,
+                mode = NumberMode.BOX,
+                entity_category = EntityCategory.CONFIG
+            )
+            entities.extend([StellantisKwhCostNumber(coordinator, description, 0)])
+
         description = NumberEntityDescription(
             name = "refresh_interval",
             key = "refresh_interval",
@@ -54,3 +67,10 @@ async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> No
         entities.extend([StellantisBaseNumber(coordinator, description, UPDATE_INTERVAL)])
 
     async_add_entities(entities)
+
+
+class StellantisKwhCostNumber(StellantisBaseNumber):
+    @property
+    def native_unit_of_measurement(self):
+        """ Native value unit of measurement. """
+        return f"{self._coordinator.currency_code}/{UnitOfEnergy.KILO_WATT_HOUR}"

--- a/custom_components/stellantis_vehicles/sensor.py
+++ b/custom_components/stellantis_vehicles/sensor.py
@@ -5,11 +5,11 @@ from copy import deepcopy
 from homeassistant.core import HomeAssistant
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.const import ( UnitOfLength, UnitOfSpeed, UnitOfEnergy, UnitOfVolume, UnitOfPower, PERCENTAGE )
-from homeassistant.components.sensor.const import ( SensorDeviceClass )
+from homeassistant.components.sensor.const import ( SensorDeviceClass, SensorStateClass )
 from homeassistant.const import EntityCategory
 
 from .base import ( StellantisBaseSensor, StellantisRestoreSensor )
-from .utils import ( get_datetime, sort_dict )
+from .utils import sort_dict
 
 from .const import (
     DOMAIN,
@@ -58,6 +58,28 @@ async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> No
                 entity_category = EntityCategory.DIAGNOSTIC
             )
             entities.extend([StellantisLastChargeSensor(coordinator, description)])
+
+            description = SensorEntityDescription(
+                name = "charge_cost",
+                key = "charge_cost",
+                translation_key = "charge_cost",
+                icon = "mdi:cash",
+                device_class = SensorDeviceClass.MONETARY,
+                suggested_display_precision = 2
+            )
+            entities.extend([StellantisChargeCostSensor(coordinator, description)])
+
+            description = SensorEntityDescription(
+                name = "actual_average_consumption",
+                key = "actual_average_consumption",
+                translation_key = "actual_average_consumption",
+                icon = "mdi:flash",
+                unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR+"/100"+UnitOfLength.KILOMETERS,
+                device_class = SensorDeviceClass.ENERGY_DISTANCE,
+                state_class = SensorStateClass.MEASUREMENT,
+                suggested_display_precision = 2
+            )
+            entities.extend([StellantisChargeMetricSensor(coordinator, description)])
 
         description = SensorEntityDescription(
             name = "type",
@@ -185,12 +207,13 @@ class StellantisLastChargeSensor(StellantisRestoreSensor):
     def __init__(self, coordinator, description) -> None:
         super().__init__(coordinator, description)
         self._sensor_key = self._key
-        self._wait_next_update = False
 
-    def coordinator_update(self):
-        in_progress = self._coordinator._sensors.get("battery_charging") == "InProgress"
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        self._coordinator.async_update_listeners()
 
-        unit_of_measurement = {
+    def _get_attribute_units(self):
+        return {
             "initial_percentage": PERCENTAGE,
             "final_percentage": PERCENTAGE,
             "recharged_percent": PERCENTAGE,
@@ -200,72 +223,71 @@ class StellantisLastChargeSensor(StellantisRestoreSensor):
             "avg_power": UnitOfPower.KILO_WATT,
             "initial_autonomy": UnitOfLength.KILOMETERS,
             "final_autonomy": UnitOfLength.KILOMETERS,
-            "recharged_autonomy": UnitOfLength.KILOMETERS
+            "recharged_autonomy": UnitOfLength.KILOMETERS,
+            "initial_mileage": UnitOfLength.KILOMETERS,
+            "final_mileage": UnitOfLength.KILOMETERS,
+            "distance_since_last_charge": UnitOfLength.KILOMETERS,
+            "charge_cost": self._coordinator.currency_code,
+            "actual_average_consumption": UnitOfEnergy.KILO_WATT_HOUR+"/100"+UnitOfLength.KILOMETERS
         }
 
-        attributes = deepcopy(self._attr_extra_state_attributes)
+    def _normalize_attributes(self, attributes):
+        units = self._get_attribute_units()
+        numbers = {
+            "initial_percentage",
+            "final_percentage",
+            "recharged_percent",
+            "initial_energy",
+            "final_energy",
+            "recharged_energy",
+            "avg_power",
+            "initial_autonomy",
+            "final_autonomy",
+            "recharged_autonomy",
+            "initial_mileage",
+            "final_mileage",
+            "distance_since_last_charge",
+            "charge_cost",
+            "actual_average_consumption"
+        }
+        integers = {"initial_percentage", "final_percentage", "recharged_percent"}
+        normalized = {}
 
-        for attribute in attributes:
-            if attribute in unit_of_measurement:
-                attributes[attribute] = attributes[attribute].replace(f" {unit_of_measurement[attribute]}", "")
-        
-        prev_in_progress = "in_progress" in attributes and attributes["in_progress"]
+        for key, value in attributes.items():
+            if key == "in_progress":
+                if isinstance(value, str):
+                    normalized[key] = value.lower() in ["true", "yes", "on"]
+                else:
+                    normalized[key] = bool(value)
+                continue
 
-        divide = 1000
-        correction_on = self._coordinator._sensors.get("switch_battery_values_correction", False)
-        if correction_on:
-            divide = divide / KWH_CORRECTION
+            if key in units and isinstance(value, str):
+                suffix = f" {units[key]}"
+                if suffix.strip() and value.endswith(suffix):
+                    value = value[:-len(suffix)]
 
-        if in_progress and not prev_in_progress:
-            self._attr_native_value = get_datetime()
-            attributes["in_progress"] = True
-            attributes["initial_percentage"] = round(self._coordinator._sensors.get("battery"))
-            if self._coordinator._sensors.get("battery_residual"):
-                attributes["initial_energy"] = round(float(self._coordinator._sensors.get("battery_residual")) / divide, 2)
-            if self._coordinator._sensors.get("autonomy"):
-                attributes["initial_autonomy"] = self._coordinator._sensors.get("autonomy")
-            try:
-                del attributes["final_time"]
-                del attributes["final_percentage"]
-                del attributes["final_energy"]
-                del attributes["final_autonomy"]
-                del attributes["duration"]
-                del attributes["recharged_percent"]
-                del attributes["recharged_energy"]
-                del attributes["recharged_autonomy"]
-                del attributes["avg_power"]
-            except KeyError:
-                pass
-        elif prev_in_progress and not in_progress:
-            if self._wait_next_update:
-                del attributes["in_progress"]
-                attributes["final_time"] = get_datetime()
-                attributes["final_percentage"] = round(self._coordinator._sensors.get("battery"))
-                if self._coordinator._sensors.get("battery_residual"):
-                    attributes["final_energy"] = round(float(self._coordinator._sensors.get("battery_residual")) / divide, 2)
-                if self._coordinator._sensors.get("autonomy"):
-                    attributes["final_autonomy"] = self._coordinator._sensors.get("autonomy")
+            if key in numbers:
+                value = self._coordinator._float_or_none(value)
+                if value is None:
+                    continue
+                if key in integers:
+                    value = round(value)
+            normalized[key] = value
 
-                duration = get_datetime(attributes["final_time"]) - self._attr_native_value
-                attributes["duration"] = strftime("%H:%M:%S", gmtime(duration.total_seconds()))
-                
-                attributes["recharged_percent"] = round(float(attributes["final_percentage"]) - float(attributes["initial_percentage"]))
-                if "initial_energy" in attributes and "final_energy" in attributes:
-                    recharged_energy = float(attributes["final_energy"]) - float(attributes["initial_energy"])
-                    attributes["recharged_energy"] = round(recharged_energy, 2)
-                    attributes["avg_power"] = round(recharged_energy / ((duration.total_seconds() / 60) / 60), 2)
-                if "initial_autonomy" in attributes and "final_autonomy" in attributes:
-                    attributes["recharged_autonomy"] = round(float(attributes["final_autonomy"]) - float(attributes["initial_autonomy"]))
+        return normalized
 
-                self._wait_next_update = False
-
-            self._wait_next_update = True
-
-        for attribute in attributes:
-            if attribute in unit_of_measurement:
-                attributes[attribute] = f"{attributes[attribute]} {unit_of_measurement[attribute]}"
+    def _format_attributes(self, attributes):
+        units = self._get_attribute_units()
+        formatted = deepcopy(attributes)
+        for key, value in list(formatted.items()):
+            if key == "in_progress":
+                continue
+            if key in units and value is not None:
+                unit = units[key]
+                formatted[key] = f"{value} {unit}" if unit else value
 
         ordered_keys = [
+            "in_progress",
             "duration",
             "final_time",
             "initial_percentage",
@@ -274,10 +296,41 @@ class StellantisLastChargeSensor(StellantisRestoreSensor):
             "initial_energy",
             "final_energy",
             "recharged_energy",
+            "charge_cost",
+            "avg_power",
             "initial_autonomy",
             "final_autonomy",
             "recharged_autonomy",
-            "avg_power"
+            "initial_mileage",
+            "final_mileage",
+            "distance_since_last_charge",
+            "actual_average_consumption"
         ]
 
-        self._attr_extra_state_attributes = sort_dict(attributes, ordered_keys)
+        return sort_dict(formatted, ordered_keys)
+
+    def coordinator_update(self):
+        last_charge_state = self._coordinator.get_last_charge_state()
+        if last_charge_state["native_value"] is None and not last_charge_state["attributes"] and (self._attr_native_value is not None or self._attr_extra_state_attributes):
+            self._coordinator.set_last_charge_state(self._attr_native_value, self._normalize_attributes(self._attr_extra_state_attributes))
+
+        last_charge_state = self._coordinator.update_charge_tracking()
+        self._attr_native_value = last_charge_state["native_value"]
+        self._coordinator._sensors[self._key] = self._attr_native_value
+        self._attr_extra_state_attributes = self._format_attributes(last_charge_state["attributes"])
+
+
+class StellantisChargeMetricSensor(StellantisRestoreSensor):
+    def coordinator_update(self):
+        last_charge_state = self._coordinator.get_last_charge_state()
+        if last_charge_state["native_value"] is None and not last_charge_state["attributes"]:
+            return
+
+        self._coordinator.update_charge_tracking()
+        self._attr_native_value = self._coordinator._sensors.get(self._key)
+
+
+class StellantisChargeCostSensor(StellantisChargeMetricSensor):
+    def coordinator_update(self):
+        self._attr_native_unit_of_measurement = self._coordinator.currency_code
+        super().coordinator_update()

--- a/custom_components/stellantis_vehicles/translations/cz.json
+++ b/custom_components/stellantis_vehicles/translations/cz.json
@@ -140,6 +140,32 @@
             "name": "Průměrná spotřeba paliva"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
+      },
+      "last_charge": {
+        "name": "Last charge",
+        "state_attributes": {
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -181,6 +207,9 @@
     "number": {
       "battery_charging_limit": {
         "name": "Limit nabíjení baterie"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/da.json
+++ b/custom_components/stellantis_vehicles/translations/da.json
@@ -151,6 +151,32 @@
             "name": "Gennemsnitlig brændstofforbrug"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
+      },
+      "last_charge": {
+        "name": "Last charge",
+        "state_attributes": {
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -222,6 +248,9 @@
       },
       "refresh_interval": {
         "name": "Opdateringsinterval"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -164,43 +164,64 @@
               "true": "Yes"
             }
           },
-            "initial_percentage": {
+          "initial_percentage": {
             "name": "Anfänglicher Ladezustand"
           },
-            "initial_energy": {
+          "initial_energy": {
             "name": "Anfängliche Energiemenge"
           },
-            "initial_autonomy": {
+          "initial_autonomy": {
             "name": "Anfängliche Reichweite"
           },
-            "final_time": {
+          "final_time": {
             "name": "Endzeit"
           },
-            "final_percentage": {
+          "final_percentage": {
             "name": "Finaler Ladezustand"
           },
-            "final_energy": {
+          "final_energy": {
             "name": "Finaler Energieinhalt"
           },
-            "final_autonomy": {
+          "final_autonomy": {
             "name": "Finale Reichweite"
           },
-            "duration": {
+          "duration": {
             "name": "Dauer des Ladevorgangs"
           },
-            "recharged_percent": {
+          "recharged_percent": {
             "name": "Aufgeladene Energie in Prozent"
           },
-            "recharged_energy": {
+          "recharged_energy": {
             "name": "Aufgeladene Energiemenge"
           },
-            "recharged_autonomy": {
+          "recharged_autonomy": {
             "name": "Aufgeladene Reichweite"
           },
           "avg_power": {
             "name": "Durchschnittliche Ladeleistung"
+          },
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
       }
     },
     "binary_sensor": {
@@ -275,6 +296,9 @@
       },
       "refresh_interval": {
         "name": "Aktualisierungsintervall"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -242,8 +242,29 @@
           },
           "avg_power": {
             "name": "Average power"
+          },
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
       }
     },
     "binary_sensor": {
@@ -318,6 +339,9 @@
       },
       "refresh_interval": {
         "name": "Refresh data interval"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/es.json
+++ b/custom_components/stellantis_vehicles/translations/es.json
@@ -242,8 +242,29 @@
           },
           "avg_power": {
             "name": "Potencia media"
+          },
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
       }
     },
     "binary_sensor": {
@@ -318,6 +339,9 @@
       },
       "refresh_interval": {
         "name": "Intervalo de actualización de datos"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/fi.json
+++ b/custom_components/stellantis_vehicles/translations/fi.json
@@ -154,6 +154,32 @@
             "name": "Polttoaineen keskikulutus"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
+      },
+      "last_charge": {
+        "name": "Last charge",
+        "state_attributes": {
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -175,7 +201,7 @@
       "preconditioning": {
         "name": "Esi-ilmastointi"
       },
-    "alarm": {
+      "alarm": {
         "name": "Hälytys"
       },
       "privacy": {
@@ -228,6 +254,9 @@
       },
       "refresh_interval": {
         "name": "Päivitysväli"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/fr.json
+++ b/custom_components/stellantis_vehicles/translations/fr.json
@@ -150,6 +150,32 @@
             "name": "Consommation carburant moyenne"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
+      },
+      "last_charge": {
+        "name": "Last charge",
+        "state_attributes": {
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -221,6 +247,9 @@
       },
       "refresh_interval": {
         "name": "Intervalle de rafraichissement des données"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/it.json
+++ b/custom_components/stellantis_vehicles/translations/it.json
@@ -242,8 +242,29 @@
           },
           "avg_power": {
             "name": "Potenza media"
+          },
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
       }
     },
     "binary_sensor": {
@@ -318,6 +339,9 @@
       },
       "refresh_interval": {
         "name": "Intervallo aggiornamento dati"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/nb.json
+++ b/custom_components/stellantis_vehicles/translations/nb.json
@@ -154,6 +154,32 @@
             "name": "Gjennomsnittlig drivstofforbruk"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
+      },
+      "last_charge": {
+        "name": "Last charge",
+        "state_attributes": {
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -228,6 +254,9 @@
       },
       "refresh_interval": {
         "name": "Oppdateringsintervall"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/nl.json
+++ b/custom_components/stellantis_vehicles/translations/nl.json
@@ -242,8 +242,29 @@
           },
           "avg_power": {
             "name": "Gemiddeld vermogen"
+          },
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
       }
     },
     "binary_sensor": {
@@ -318,6 +339,9 @@
       },
       "refresh_interval": {
         "name": "Data refresh interval"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/no.json
+++ b/custom_components/stellantis_vehicles/translations/no.json
@@ -88,6 +88,32 @@
       },
       "fuel_consumption_instant": {
         "name": "Øyeblikkelig drivstofforbruk"
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
+      },
+      "last_charge": {
+        "name": "Last charge",
+        "state_attributes": {
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -132,6 +158,9 @@
     "number": {
       "battery_charging_limit": {
         "name": "Batteri ladegrense"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/pl.json
+++ b/custom_components/stellantis_vehicles/translations/pl.json
@@ -132,6 +132,32 @@
             "name": "Średni zużycie paliwa"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
+      },
+      "last_charge": {
+        "name": "Last charge",
+        "state_attributes": {
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -203,8 +229,11 @@
       "battery_charging_limit": {
         "name": "Limit ładowania baterii"
       },
-    "refresh_interval": {
+      "refresh_interval": {
         "name": "Czestotliwość odświeżania"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/pt.json
+++ b/custom_components/stellantis_vehicles/translations/pt.json
@@ -154,6 +154,32 @@
             "name": "Consumo de combustível médio"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
+      },
+      "last_charge": {
+        "name": "Last charge",
+        "state_attributes": {
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -228,6 +254,9 @@
       },
       "refresh_interval": {
         "name": "Intervalo de atualização de dados"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/custom_components/stellantis_vehicles/translations/sv.json
+++ b/custom_components/stellantis_vehicles/translations/sv.json
@@ -231,8 +231,29 @@
           },
           "avg_power": {
             "name": "Genomsnittlig effekt"
+          },
+          "initial_mileage": {
+            "name": "Initial mileage"
+          },
+          "final_mileage": {
+            "name": "Final mileage"
+          },
+          "distance_since_last_charge": {
+            "name": "Distance since last charge"
+          },
+          "charge_cost": {
+            "name": "Charge cost"
+          },
+          "actual_average_consumption": {
+            "name": "Actual average consumption"
           }
         }
+      },
+      "charge_cost": {
+        "name": "Charge cost"
+      },
+      "actual_average_consumption": {
+        "name": "Actual average consumption"
       }
     },
     "binary_sensor": {
@@ -307,6 +328,9 @@
       },
       "refresh_interval": {
         "name": "Uppdateringsfrekvens"
+      },
+      "kwh_cost": {
+        "name": "kWh cost"
       }
     },
     "switch": {

--- a/info.md
+++ b/info.md
@@ -9,6 +9,7 @@
 - [OAuth2 Code](#oauth2-code)
 - [Commands](#commands)
 - [Battery capacity / residual sensors](#battery-capacity--residual-sensors)
+- [Charge cost / actual consumption](#charge-cost--actual-consumption)
 - [Card: Stellantis Vehicles](#card-stellantis-vehicles)
 - [Global preferences](#global-preferences)
 - [Errors](#errors)
@@ -171,6 +172,18 @@ As described in the Stellantis apps, the command is enabled when:
 Thanks to the community ([#272](https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/272)), it seems that for some vehicles **Stellantis provides incorrect values**. The **switch.battery_values_correction** entity (in your language) applies a correction if active.
 
 \*currently only to the battery_residual sensor
+
+## Charge cost / actual consumption
+Charge-capable vehicles now expose:
+- **number.kwh_cost** to set your per-vehicle electricity tariff
+- **sensor.charge_cost** for the latest completed charge cost
+- **sensor.actual_average_consumption** for the real-world efficiency since the previous completed charge, in `kWh/100km`
+
+The existing **sensor.last_charge** entity also includes charge cost, mileage, distance since last charge, and actual average consumption in its attributes.
+
+Charge cost stays unavailable until you set **number.kwh_cost** to a value greater than `0`.
+
+The first valid **sensor.actual_average_consumption** value requires **two completed charges recorded by this version**, because it uses the distance driven between charge sessions.
 
 ## Card: Stellantis Vehicles
 A new custom card is available to manage the vehicle, the card is configurable from the visual editor or via yaml:


### PR DESCRIPTION
## Summary

This PR adds charge cost tracking and a real-world average consumption sensor for charge-capable vehicles.

New entities:
- `number.kwh_cost` to set the electricity price per vehicle
- `sensor.charge_cost` to show the cost of the latest completed charge
- `sensor.actual_average_consumption` to show actual average consumption in `kWh/100km`

`sensor.last_charge` now also stores mileage, distance since last charge, charge cost, and actual average consumption.

## Why

This makes it easier to track what a charge really costs and how efficient the car is between charging sessions.

For example, on my Corsa-e 2020, I wanted to see the real consumption based on the energy added during charging and the distance driven since the previous full charge session, instead of only relying on the trip value reported by the app.

## Notes

- Charge cost stays unavailable until `number.kwh_cost` is set above `0`
- Actual average consumption becomes available after enough charge history exists, typically after the second completed charge recorded by this version
- Battery value correction is also applied to the derived charge metrics so the numbers stay consistent

## Validation

- `python -m compileall custom_components/stellantis_vehicles`
