### PR TITLE
fix: proactive OAuth refresh token expiry and handle 50000 as transient

### DIFF
--- a/custom_components/stellantis_vehicles/config_flow.py
+++ b/custom_components/stellantis_vehicles/config_flow.py
@@ -28,6 +28,7 @@ from .const import (
     FIELD_ANONYMIZE_LOGS,
     FIELD_RECONFIGURE,
     MQTT_REFRESH_TOKEN_TTL,
+    OAUTH_REFRESH_TOKEN_TTL,
     TRANSLATION_PLACEHOLDERS
 )
 
@@ -187,7 +188,8 @@ class StellantisVehiclesConfigFlow(ConfigFlow, domain=DOMAIN):
             oauth = {"oauth": {
                 "access_token": token_request["access_token"],
                 "refresh_token": token_request["refresh_token"],
-                "expires_in": (get_datetime() + timedelta(0, int(token_request["expires_in"]))).isoformat()
+                "expires_in": (get_datetime() + timedelta(0, int(token_request["expires_in"]))).isoformat(),
+                "refresh_token_expires_at": (get_datetime() + timedelta(minutes=int(OAUTH_REFRESH_TOKEN_TTL))).isoformat()
             }}
             self.data.update(oauth)
             self.stellantis.save_config(oauth)

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -22,6 +22,7 @@ with open(os.path.dirname(os.path.abspath(__file__)) + "/configs.json", "r") as 
     MOBILE_APPS = json.load(f)
 
 MQTT_REFRESH_TOKEN_TTL = (60*24*3) # 3 days
+OAUTH_REFRESH_TOKEN_TTL = (60*24*7) # 7 days
 OTP_FILENAME = "{#customer_id#}_otp.pickle"
 
 OAUTH_BASE_URL = "{#oauth_url#}/am/oauth2"

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -57,6 +57,7 @@ from .const import (
     CAR_API_GET_VEHICLE_TRIPS_URL,
     MQTT_REFRESH_TOKEN_JSON_DATA,
     MQTT_REFRESH_TOKEN_TTL,
+    OAUTH_REFRESH_TOKEN_TTL,
     OTP_FILENAME,
     ABRP_URL,
     ABRP_API_KEY,
@@ -226,10 +227,9 @@ class StellantisBase:
                     result = {}
                 elif str(resp.status) == "500" and result.get("code", None) == "50000":
                     # Connection module replaced (https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/388)
-                    raise ConfigEntryAuthFailed(error)
+                    raise ComunicationError(error)
                 elif str(resp.status) == "400" and result.get("error", None) == "invalid_grant":
-                    # Token expiration
-                    raise ConfigEntryAuthFailed(error)
+                    raise ConfigEntryAuthFailed("Stellantis Vehicles authentication expired (invalid_grant). Please re-authenticate the integration.")
                 elif str(resp.status) == "401":
                     # Oauth token seem expired, refresh request blocked by server/connection error
                     raise ComunicationError(error)
@@ -522,6 +522,11 @@ class StellantisVehicles(StellantisOauth):
         def get_next_run():
             expires_in = self.get_config("oauth")["expires_in"]
             return datetime.fromisoformat(expires_in) - timedelta(minutes=5)
+        oauth_config = self.get_config("oauth")
+        if "refresh_token_expires_at" in oauth_config:
+            refresh_expires = datetime.fromisoformat(oauth_config["refresh_token_expires_at"])
+            if get_datetime() > refresh_expires - timedelta(hours=1):
+                raise ConfigEntryAuthFailed("Stellantis Vehicles: OAuth refresh token is about to expire. Please re-authenticate the integration.")
         try:
             if self._oauth_token_scheduled is not None:
                 self.reset_scheduled_oauth_token()
@@ -554,7 +559,8 @@ class StellantisVehicles(StellantisOauth):
         new_config = {
             "access_token": token_request["access_token"],
             "refresh_token": token_request["refresh_token"],
-            "expires_in": (get_datetime() + timedelta(seconds=int(token_request["expires_in"]))).isoformat()
+            "expires_in": (get_datetime() + timedelta(seconds=int(token_request["expires_in"]))).isoformat(),
+            "refresh_token_expires_at": (get_datetime() + timedelta(minutes=int(OAUTH_REFRESH_TOKEN_TTL))).isoformat()
         }
         self.save_config({"oauth": new_config})
         self.update_stored_config("oauth", new_config)


### PR DESCRIPTION
## Summary

This PR addresses two related stability issues:

1. **Proactive OAuth refresh token expiry tracking** — Stellantis OAuth refresh tokens expire after approximately 7 days. Currently the integration only discovers this when the API returns invalid_grant, which forces a manual re-authentication flow. This PR tracks the refresh token expiry and raises ConfigEntryAuthFailed one hour before expiration, allowing Home Assistant to trigger the re-authentication UI proactively.

2. **Treat API error 50000 as transient instead of auth failure** — When the car lights are turned on, the Stellantis API returns HTTP 500 with code 50000 (\"Connection module replaced\"). The current code raises ConfigEntryAuthFailed for this, which crashes the DataUpdateCoordinator and marks all entities as unavailable. This PR changes the handling to raise ComunicationError, so the coordinator retries on the next poll cycle and entities remain available.

## Changes

- const.py: Add OAUTH_REFRESH_TOKEN_TTL = 60*24*7 (7 days)
- config_flow.py: Save refresh_token_expires_at on initial token exchange
- stellantis.py:
  - Save refresh_token_expires_at during refresh_token_request()
  - Check expiry proactively in scheduled_oauth_token_refresh()
  - Improve invalid_grant error message clarity in make_http_request()
  - Treat 50000 as ComunicationError instead of ConfigEntryAuthFailed

## Related Issues

- Fixes the root cause behind invalid_grant re-authentication cycles
- Fixes https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/388