### PR TITLE
fix: pass config entry explicitly to coordinator

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -32,8 +32,8 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 class StellantisVehicleCoordinator(DataUpdateCoordinator):
-    def __init__(self, hass:HomeAssistant, config, vehicle, stellantis, translations) -> None:
-        super().__init__(hass, _LOGGER, name = DOMAIN, update_interval=timedelta(seconds=UPDATE_INTERVAL))
+    def __init__(self, hass:HomeAssistant, config, vehicle, stellantis, translations, config_entry) -> None:
+        super().__init__(hass, _LOGGER, config_entry=config_entry, name = DOMAIN, update_interval=timedelta(seconds=UPDATE_INTERVAL))
 
         self._hass = hass
         self._translations = translations

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -476,7 +476,7 @@ class StellantisVehicles(StellantisOauth):
         if vin in self._coordinator_dict:
             return self._coordinator_dict[vin]
         translations = await translation.async_get_translations(self._hass, self._hass.config.language, "entity", {DOMAIN})
-        coordinator = StellantisVehicleCoordinator(self._hass, self._config, vehicle, self, translations)
+        coordinator = StellantisVehicleCoordinator(self._hass, self._config, vehicle, self, translations, config_entry=self._entry)
         self._coordinator_dict[vin] = coordinator
         return coordinator
 


### PR DESCRIPTION
## Summary

Pass the integration config entry explicitly to
`DataUpdateCoordinator`.

This removes reliance on the implicit config-entry context and prepares
the coordinator wiring for the Home Assistant 2026.8 behavior change.

## Changes

- Add `config_entry` to `StellantisVehicleCoordinator`.
- Pass it to `DataUpdateCoordinator`.
- Pass the integration entry from `StellantisVehicles`.

## Validation

- [x] Python compilation
- [x] Static AST validation
- [x] Home Assistant 2026.6.3 startup
- [x] Existing configuration loads
- [x] Sensors continue updating
- [x] Home Assistant configuration check
- [x] No Stellantis errors in initial logs
- [ ] Seven-day stability period completed
- [ ] New installation tested
- [ ] Reconfiguration tested

Remote commands are disabled and unavailable for the test vehicle, so
no remote command was sent during validation.
