### PR TITLE
added check for old 'createdAt' time stamps to _async_update_data()

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -69,7 +69,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                         accepted_new_data = True
                     elif new_data_time < old_data_time:
                         # If the received data set is actually older, log a warning
-                        _LOGGER.warning(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time})")
+                        _LOGGER.warning(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time}")
                 else:
                     self._data = new_data
                     accepted_new_data = True

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -59,20 +59,19 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         try:
             # Vehicle status
             new_data = await self._stellantis.get_vehicle_status(self._vehicle)
-            if "createdAt" in new_data:
-                if "createdAt" in self._data:
-                    old_data_time = datetime.fromisoformat(self._data["createdAt"])
-                    new_data_time = datetime.fromisoformat(new_data["createdAt"])
-                    if new_data_time > old_data_time:
-                        # Only accept new data sets that are actually newer than the last one
-                        self._data = new_data
-                        accepted_new_data = True
-                    elif new_data_time < old_data_time:
-                        # If the received data set is actually older, log a warning
-                        _LOGGER.warning(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time}")
-                else:
+            if "createdAt" in new_data and "createdAt" in self._data:
+                old_data_time = datetime.fromisoformat(self._data["createdAt"])
+                new_data_time = datetime.fromisoformat(new_data["createdAt"])
+                if new_data_time > old_data_time:
+                    # Only accept new data sets that are actually newer than the last one
                     self._data = new_data
                     accepted_new_data = True
+                elif new_data_time < old_data_time:
+                    # If the received data set is actually older, log a warning
+                    _LOGGER.warning(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time}")
+            else:
+                self._data = new_data
+                accepted_new_data = True
         except ConfigEntryAuthFailed:
             _LOGGER.debug("---------- END _async_update_data")
             raise

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -55,6 +55,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         """ Update vehicle data from Stellantis. """
         _LOGGER.debug("---------- START _async_update_data")
         _LOGGER.debug(self._config)
+        accepted_new_data = False
         try:
             # Vehicle status
             new_data = await self._stellantis.get_vehicle_status(self._vehicle)
@@ -65,6 +66,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                     if new_data_time > old_data_time:
                         # Only accept new data sets that are actually newer than the last one
                         self._data = new_data
+                        accepted_new_data = True
                     elif new_data_time < old_data_time:
                         # If the received data set is actually older, log a warning
                         _LOGGER.warning(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time})")
@@ -75,7 +77,8 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             raise
         except Exception:
             pass
-        await self.after_async_update_data()
+        if accepted_new_data:
+            await self.after_async_update_data()
         _LOGGER.debug("---------- END _async_update_data")
 
     def get_translation(self, path, default = None):

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -63,11 +63,11 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                     old_data_time = datetime.fromisoformat(self._data["createdAt"])
                     new_data_time = datetime.fromisoformat(new_data["createdAt"])
                     if new_data_time > old_data_time:
+                        # Only accept new data sets that are actually newer than the last one
                         self._data = new_data
                     elif new_data_time < old_data_time:
-                        _LOGGER.warning("Discarded stale data set - received 'createdAt' too old:")
-                        _LOGGER.warning(f"  self._data['createdAt']: {old_data_time}")
-                        _LOGGER.warning(f"    new_data['createdAt']: {new_data_time})")
+                        # If the received data set is actually older, log a warning
+                        _LOGGER.warning(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time})")
                 else:
                     self._data = new_data
         except ConfigEntryAuthFailed:

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -70,6 +70,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                     elif new_data_time < old_data_time:
                         # If the received data set is actually older, log a warning
                         _LOGGER.debug(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time}")
+                    # Discard data sets that have the same 'createdAt' value as the last accepted data set (not new but also not old)
                 else:
                     self._data = new_data
                     accepted_new_data = True

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -68,7 +68,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                     accepted_new_data = True
                 elif new_data_time < old_data_time:
                     # If the received data set is actually older, log a warning
-                    _LOGGER.warning(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time}")
+                    _LOGGER.debug(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time}")
             else:
                 self._data = new_data
                 accepted_new_data = True

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -72,6 +72,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                         _LOGGER.warning(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time})")
                 else:
                     self._data = new_data
+                    accepted_new_data = True
         except ConfigEntryAuthFailed:
             _LOGGER.debug("---------- END _async_update_data")
             raise

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -57,7 +57,19 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         _LOGGER.debug(self._config)
         try:
             # Vehicle status
-            self._data = await self._stellantis.get_vehicle_status(self._vehicle)
+            new_data = await self._stellantis.get_vehicle_status(self._vehicle)
+            if "createdAt" in new_data:
+                if "createdAt" in self._data:
+                    old_data_time = datetime.fromisoformat(self._data["createdAt"])
+                    new_data_time = datetime.fromisoformat(new_data["createdAt"])
+                    if new_data_time > old_data_time:
+                        self._data = new_data
+                    elif new_data_time < old_data_time:
+                        _LOGGER.warning("Discarded stale data set - received 'createdAt' too old:")
+                        _LOGGER.warning(f"  self._data['createdAt']: {old_data_time}")
+                        _LOGGER.warning(f"    new_data['createdAt']: {new_data_time})")
+                else:
+                    self._data = new_data
         except ConfigEntryAuthFailed:
             _LOGGER.debug("---------- END _async_update_data")
             raise

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -59,19 +59,25 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         try:
             # Vehicle status
             new_data = await self._stellantis.get_vehicle_status(self._vehicle)
-            if "createdAt" in new_data and "createdAt" in self._data:
-                old_data_time = datetime.fromisoformat(self._data["createdAt"])
-                new_data_time = datetime.fromisoformat(new_data["createdAt"])
-                if new_data_time > old_data_time:
-                    # Only accept new data sets that are actually newer than the last one
+            try:
+                if "createdAt" in new_data and "createdAt" in self._data:
+                    old_data_time = datetime.fromisoformat(self._data["createdAt"])
+                    new_data_time = datetime.fromisoformat(new_data["createdAt"])
+                    if new_data_time > old_data_time:
+                        # Only accept new data sets that are actually newer than the last one
+                        self._data = new_data
+                        accepted_new_data = True
+                    elif new_data_time < old_data_time:
+                        # If the received data set is actually older, log a warning
+                        _LOGGER.debug(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time}")
+                else:
                     self._data = new_data
                     accepted_new_data = True
-                elif new_data_time < old_data_time:
-                    # If the received data set is actually older, log a warning
-                    _LOGGER.debug(f"Discarded stale data set - new 'createdAt' too old: self._data: {old_data_time}, new_data: {new_data_time}")
-            else:
+                    _LOGGER.debug("Accepted data set with missing 'createdAt'")
+            except ValueError:
                 self._data = new_data
                 accepted_new_data = True
+                _LOGGER.debug("Accepted data set with corrupt 'createdAt'")
         except ConfigEntryAuthFailed:
             _LOGGER.debug("---------- END _async_update_data")
             raise


### PR DESCRIPTION
This is necessary because the Stellantis API sometimes responds with data sets that are older than previous ones, which may result for example in decreasing odometer values.

Should fix #488