### PR TITLE
Fail fast on worker timeout, accept full URL in manual OAuth code

### DIFF
--- a/custom_components/stellantis_vehicles/config_flow.py
+++ b/custom_components/stellantis_vehicles/config_flow.py
@@ -1,6 +1,7 @@
 import logging
 import voluptuous as vol
 from datetime import timedelta
+from urllib.parse import urlparse, parse_qs
 from uuid import uuid4
 
 from homeassistant.config_entries import ( ConfigFlow, SOURCE_REAUTH, SOURCE_RECONFIGURE )
@@ -168,8 +169,25 @@ class StellantisVehiclesConfigFlow(ConfigFlow, domain=DOMAIN):
             oauth_devtools = f"\n\n>***://oauth2redirect...?code=`{oauth_label}`&scope=openid..."
             return self.async_show_form(step_id="oauth_manual", data_schema=OAUTH_MANUAL_SCHEMA, description_placeholders={"oauth_link": oauth_link, "oauth_label": oauth_label, "oauth_devtools": oauth_devtools}, errors=errors)
 
-        self.stellantis.save_config({"oauth_code": user_input[FIELD_OAUTH_CODE]})
+        self.stellantis.save_config({"oauth_code": self._extract_oauth_code(user_input[FIELD_OAUTH_CODE])})
         return await self.async_step_get_access_token()
+
+
+    @staticmethod
+    def _extract_oauth_code(raw_value):
+        """Accept either a bare code or the full (failed) redirect URL and return just the code.
+
+        The redirect after login is a custom app scheme (e.g. mymacsdk://oauth2redirect/...)
+        that browsers can't open, so users often copy the whole broken-link URL rather than
+        hand-picking the code query param out of it.
+        """
+        value = raw_value.strip()
+        if "code=" in value and ("://" in value or value.startswith("?")):
+            query = urlparse(value).query
+            code_values = parse_qs(query).get("code")
+            if code_values:
+                return code_values[0]
+        return value
 
 
     async def async_step_get_access_token(self, user_input=None):

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -295,7 +295,10 @@ class StellantisOauth(StellantisBase):
 
     async def get_oauth_code(self, email, password):
         _LOGGER.debug("---------- START get_oauth_code")
-        oauth_code_request = await self.make_http_request(OAUTH_CODE_URL, 'POST', None, None, {"url": self.get_oauth_url(), "email": email, "password": password}, None, 300)
+        # The external worker can hang indefinitely instead of erroring, so a
+        # 300s timeout meant users waited 5 minutes to see any failure. 60s is
+        # still generous for a cold-start free-tier instance, but fails fast.
+        oauth_code_request = await self.make_http_request(OAUTH_CODE_URL, 'POST', None, None, {"url": self.get_oauth_url(), "email": email, "password": password}, None, 60)
         if "code" in oauth_code_request:
             self.logger_filter.add_custom_value(oauth_code_request["code"])
         _LOGGER.debug(oauth_code_request)


### PR DESCRIPTION
## Summary
- Reduces the OAuth worker request timeout from 300s to 60s (`stellantis.py`). The worker (`homeassistant-stellantis-vehicles-worker.onrender.com`) can hang indefinitely instead of returning an error, so a failed login currently means waiting up to 5 minutes before seeing any feedback. 60s still gives a cold-starting free-tier instance time to wake up, but fails fast otherwise using the existing `ComunicationError("Request timeout")` path — no new error handling needed.
- Lets the manual OAuth code field (`config_flow.py`, `async_step_oauth_manual`) accept the whole redirect URL instead of requiring users to hand-extract the `code` query param. The post-login redirect goes to a custom app scheme (e.g. `mymacsdk://oauth2redirect/...`) that desktop/mobile browsers can't open, so in practice users copy the entire broken-link URL from the address bar rather than picking out just the code. A small helper parses `code=` out of it if present; a bare code still works exactly as before.

Both changes are small and isolated — no changes to the auth flow logic itself, just timeout tuning and input parsing.

## Test plan
- [x] Verified both files parse (`ast.parse`) with no syntax errors
- [x] Applied both changes locally against a live HA instance running this integration (version 2026.7.2); HA restarts cleanly and the integration loads without errors
- [ ] Would appreciate a maintainer/other user confirming the manual-mode paste-URL flow end-to-end with a real login, since I hit the worker being unresponsive rather than the manual path itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)