### PR TITLE
Fix: potential bug in scheduled_mqtt_token_refresh

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -656,10 +656,8 @@ class StellantisVehicles(StellantisOauth):
             expires_in = mqtt_config["expires_in"]
             return datetime.fromisoformat(expires_in) - timedelta(minutes=3)
         try:
-            if self._mqtt_token_scheduled is not None or force:
-                self.reset_scheduled_mqtt_token()
-                await self.refresh_mqtt_token_request()
-            elif get_datetime() > get_next_run():
+            self.reset_scheduled_mqtt_token()
+            if force or get_datetime() > get_next_run():
                 await self.refresh_mqtt_token_request()
             next_run = get_next_run()
         except ComunicationError:


### PR DESCRIPTION
_Goal: Refresh the MQTT token only when it actually needs to be renewed or when an update is forced due to an error, so as not to place unnecessary strain on the rate limit._

`scheduled_mqtt_token_refresh` used `_mqtt_token_scheduled` is not None as a proxy for "refresh is due", but that field stays non-None for the whole lifetime of the pending timer. As a result, every command sent via `send_mqtt_message` forced a full token refresh regardless of actual expiry. The due-time check now gates the refresh directly, and the timer-cancel logic is consolidated into a single unconditional step at the top of the function as `reset_scheduled_mqtt_token` is already taking care of None/non-None conditions.

_Note: A similar situation appears to exist in "scheduled_oauth_token_refresh," but this should not be an issue, as "scheduled_oauth_token_refresh" is apparently not called outside of a scheduled timer (no force option)._