### PR TITLE
Fix: No longer ignore result_code "901" (vehicle asleep) and correct related translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 - [Card: Stellantis Vehicles](#card-stellantis-vehicles)
 - [Global preferences](#global-preferences)
 - [Errors](#errors)
+  - [OTP error - NOK:MAXNBTOOLS](#otp-error---nokmaxnbtools)
+  - [OTP error - NOK:NOK_BLOCKED](#otp-error---noknok_blocked)
+  - [Get oauth code error](#get-oauth-code-error)
+  - [Command status 901 and 300 - Wakeup timeout](#command-status-901-and-300---wakeup-timeout)
 - [ABRP - A Better Routeplanner](#abrp---a-better-routeplanner)
 - [Support the project](#support-the-project)
 
@@ -228,6 +232,17 @@ It seems that this error is due to reaching the limit of wrong PIN used. Re-auth
 As described in the "OAuth2 Code > [Remote service](#remote-service)" section, this free service has usage limitations.  
 If you've hit these limits, please wait and try again.  
 If the problem persists or is unrelated to usage limits, please use "OAuth2 Code > [Manual](#manual)" mode.
+
+### Command status 901 and 300 - Wakeup timeout
+**901 (Wakeup Vehicle)** is the wakeup command being forwarded from the Stellantis backend to your vehicle, it doesn't say anything about the vehicle's state by itself. If it's followed by **300 (Timeout)** instead of **0 (Complete)**, the vehicle didn't respond, which means it's in a deep sleep.
+
+Stellantis disables connectivity to protect the 12V battery, the vehicle apps explain it like this:
+
+> Your vehicle has not been used for more than 15 consecutive minutes in the last 7 days. To preserve your 12V battery, connectivity is disabled.
+
+This is tracked per vehicle, not per integration: any trip shorter than 15 minutes doesn't count, no matter how close it gets. If all your trips in the last 7 days were under 15 minutes, connectivity gets disabled and every wakeup times out until a trip passes the threshold again.
+
+To avoid repeated timeouts, take at least one trip longer than 15 minutes every 7 days.
 
 ## ABRP - A Better Routeplanner
 Get a token from [ABRP](https://abetterrouteplanner.com/):

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -813,8 +813,7 @@ class StellantisVehicles(StellantisOauth):
                         _LOGGER.debug(f"Fetch updates after code: {result_code}")
                         self.do_async(coordinator.async_refresh(), 10)
 
-                    if result_code != "901":  # Not store "Vehicle as sleep" event
-                        self.do_async(coordinator.update_command_history(data["correlation_id"], result_code))
+                    self.do_async(coordinator.update_command_history(data["correlation_id"], result_code))
                 else:
                     _LOGGER.error("No result code")
 

--- a/custom_components/stellantis_vehicles/translations/cz.json
+++ b/custom_components/stellantis_vehicles/translations/cz.json
@@ -84,10 +84,10 @@
         "state": {
           "not_compatible": "Nekompatibilní",
           "900": "Přijato",
-          "901": "Vozidlo spí",
+          "901": "Probuzení vozidla",
           "903": "Předáno",
           "0": "Dokončeno",
-          "300": "Zrušeno",
+          "300": "Časový limit vypršel",
           "500": "Chyba"
         }
       },

--- a/custom_components/stellantis_vehicles/translations/da.json
+++ b/custom_components/stellantis_vehicles/translations/da.json
@@ -93,10 +93,10 @@
         "state": {
           "not_compatible": "Ikke kompatibel",
           "900": "Accepteret",
-          "901": "Køretøjet er i dvaletilstand",
+          "901": "Vækker køretøjet",
           "903": "Videresendt",
           "0": "Udført",
-          "300": "Annuleret",
+          "300": "Tidsudløb",
           "500": "Fejl",
           "502": "Gentagelse",
           "422": "Privatlivstilstand slået til"

--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -96,12 +96,12 @@
         "state": {
           "0": "Abgeschlossen",
           "not_compatible": "Nicht kompatibel",
-          "300": "Abgebrochen",
+          "300": "Zeitüberschreitung",
           "422": "Alarmanlage aktiviert",
           "500": "Fehler",
           "502": "Doppelt",
           "900": "Akzeptiert",
-          "901": "Fahrzeug schläft",
+          "901": "Fahrzeug aufwecken",
           "903": "Weitergeleitet"
         }
       },

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -142,10 +142,10 @@
           "not_compatible": "Not compatible",
           "failed": "Failed",
           "900": "Accepted",
-          "901": "Vehicle as sleep",
+          "901": "Wakeup Vehicle",
           "903": "Forwarded",
           "0": "Complete",
-          "300": "Canceled",
+          "300": "Timeout",
           "500": "Error",
           "502": "Duplicate",
           "422": "Privacy enabled"

--- a/custom_components/stellantis_vehicles/translations/es.json
+++ b/custom_components/stellantis_vehicles/translations/es.json
@@ -139,10 +139,10 @@
           "not_compatible": "No compatible",
           "failed": "Fallido",
           "900": "Aceptado",
-          "901": "Vehículo en reposo",
+          "901": "Despertar vehículo",
           "903": "Reenviado",
           "0": "Completado",
-          "300": "Cancelado",
+          "300": "Tiempo de espera agotado",
           "500": "Error",
           "502": "Duplicado",
           "422": "Privacidad activada"

--- a/custom_components/stellantis_vehicles/translations/fi.json
+++ b/custom_components/stellantis_vehicles/translations/fi.json
@@ -96,10 +96,10 @@
         "state": {
           "not_compatible": "Ei yhteensopiva",
           "900": "Hyväksytty",
-          "901": "Lepotilassa",
+          "901": "Ajoneuvon herätys",
           "903": "Yhdistetty autoon",
           "0": "Suoritettu",
-          "300": "Keskeytetty",
+          "300": "Aikakatkaisu",
           "500": "Virhe",
           "502": "Komento jo käynnissä",
           "422": "Yksityisyys käytössä"

--- a/custom_components/stellantis_vehicles/translations/fr.json
+++ b/custom_components/stellantis_vehicles/translations/fr.json
@@ -93,10 +93,10 @@
         "state": {
           "not_compatible": "Non compatible",
           "900": "Acceptée",
-          "901": "Véhicule en veille",
+          "901": "Réveil du véhicule",
           "903": "Transmise",
           "0": "Terminée",
-          "300": "Annulée",
+          "300": "Délai d'attente dépassé",
           "500": "Erreur",
           "502": "Dupliquée"
         }

--- a/custom_components/stellantis_vehicles/translations/it.json
+++ b/custom_components/stellantis_vehicles/translations/it.json
@@ -142,10 +142,10 @@
           "not_compatible": "Non compatibile",
           "failed": "Fallito",
           "900": "Accettato",
-          "901": "Il veicolo dorme",
+          "901": "Risveglio del veicolo",
           "903": "Inoltrato",
           "0": "Completato",
-          "300": "Annullato",
+          "300": "Timeout",
           "500": "Errore",
           "502": "Duplicato",
           "422": "Privacy attiva"

--- a/custom_components/stellantis_vehicles/translations/nb.json
+++ b/custom_components/stellantis_vehicles/translations/nb.json
@@ -96,10 +96,10 @@
         "state": {
           "not_compatible": "Ikke kompatibel",
           "900": "Godkjent",
-          "901": "Kjøretøy i dvalemodus",
+          "901": "Vekker kjøretøyet",
           "903": "Videresendt",
           "0": "Fullført",
-          "300": "Avbrutt",
+          "300": "Tidsavbrudd",
           "500": "Feil",
           "502": "Duplikat",
           "422": "Personvern aktivert"

--- a/custom_components/stellantis_vehicles/translations/nl.json
+++ b/custom_components/stellantis_vehicles/translations/nl.json
@@ -139,10 +139,10 @@
           "not_compatible": "Niet compatibel",
           "failed": "Mislukt",
           "900": "Geaccepteerd",
-          "901": "Voertuig in slaapmodus",
+          "901": "Voertuig wekken",
           "903": "Doorgestuurd",
           "0": "Afgerond",
-          "300": "Geannuleerd",
+          "300": "Time-out",
           "500": "Error",
           "502": "Dubbel",
           "422": "Privacy ingeschakeld"

--- a/custom_components/stellantis_vehicles/translations/no.json
+++ b/custom_components/stellantis_vehicles/translations/no.json
@@ -70,10 +70,10 @@
         "state": {
           "not_compatible": "Ikke kompatibel",
           "900": "Akseptert",
-          "901": "Kjøretøy i hvilemodus",
+          "901": "Vekker kjøretøyet",
           "903": "Sendt til kjøretøyet",
           "0": "Ferdig",
-          "300": "Avbrutt",
+          "300": "Tidsavbrudd",
           "500": "Feil"
         }
       },

--- a/custom_components/stellantis_vehicles/translations/pl.json
+++ b/custom_components/stellantis_vehicles/translations/pl.json
@@ -76,10 +76,10 @@
         "state": {
           "not_compatible": "Nie kompatybilne",
           "900": "Zaakceptowano",
-          "901": "Pojazd w uśpieniu",
+          "901": "Budzenie pojazdu",
           "903": "Przekazano",
           "0": "Zakończono",
-          "300": "Anulowano",
+          "300": "Przekroczono limit czasu",
           "500": "Błąd"
         }
       },

--- a/custom_components/stellantis_vehicles/translations/pt.json
+++ b/custom_components/stellantis_vehicles/translations/pt.json
@@ -96,10 +96,10 @@
         "state": {
           "99": "Incompatível",
           "900": "Aceito",
-          "901": "Veículo em repouso",
+          "901": "Despertar veículo",
           "903": "Encaminhado",
           "0": "Completo",
-          "300": "Cancelado",
+          "300": "Tempo esgotado",
           "500": "Erro",
           "502": "Duplicado",
           "422": "Privacidade ativada"

--- a/custom_components/stellantis_vehicles/translations/sv.json
+++ b/custom_components/stellantis_vehicles/translations/sv.json
@@ -128,10 +128,10 @@
           "not_compatible": "Ej kompatibel",
           "failed": "Misslyckad",
           "900": "Accepterad",
-          "901": "Fordonet i viloläge",
+          "901": "Väcker fordonet",
           "903": "Skickat till fordonet",
           "0": "Klar",
-          "300": "Avbruten",
+          "300": "Tidsgräns överskriden",
           "500": "Fel",
           "502": "Duplikat",
           "422": "Sekretess påslagen"

--- a/info.md
+++ b/info.md
@@ -12,6 +12,10 @@
 - [Card: Stellantis Vehicles](#card-stellantis-vehicles)
 - [Global preferences](#global-preferences)
 - [Errors](#errors)
+  - [OTP error - NOK:MAXNBTOOLS](#otp-error---nokmaxnbtools)
+  - [OTP error - NOK:NOK_BLOCKED](#otp-error---noknok_blocked)
+  - [Get oauth code error](#get-oauth-code-error)
+  - [Command status 901 and 300 - Wakeup timeout](#command-status-901-and-300---wakeup-timeout)
 - [ABRP - A Better Routeplanner](#abrp---a-better-routeplanner)
 - [Support the project](#support-the-project)
 
@@ -228,6 +232,17 @@ It seems that this error is due to reaching the limit of wrong PIN used. Re-auth
 As described in the "OAuth2 Code > [Remote service](#remote-service)" section, this free service has usage limitations.  
 If you've hit these limits, please wait and try again.  
 If the problem persists or is unrelated to usage limits, please use "OAuth2 Code > [Manual](#manual)" mode.
+
+### Command status 901 and 300 - Wakeup timeout
+**901 (Wakeup Vehicle)** is the wakeup command being forwarded from the Stellantis backend to your vehicle, it doesn't say anything about the vehicle's state by itself. If it's followed by **300 (Timeout)** instead of **0 (Complete)**, the vehicle didn't respond, which means it's in a deep sleep.
+
+Stellantis disables connectivity to protect the 12V battery, the vehicle apps explain it like this:
+
+> Your vehicle has not been used for more than 15 consecutive minutes in the last 7 days. To preserve your 12V battery, connectivity is disabled.
+
+This is tracked per vehicle, not per integration: any trip shorter than 15 minutes doesn't count, no matter how close it gets. If all your trips in the last 7 days were under 15 minutes, connectivity gets disabled and every wakeup times out until a trip passes the threshold again.
+
+To avoid repeated timeouts, take at least one trip longer than 15 minutes every 7 days.
 
 ## ABRP - A Better Routeplanner
 Get a token from [ABRP](https://abetterrouteplanner.com/):


### PR DESCRIPTION
As described in #527 (and confirmed by my own observations), the vehicle appears to enter "deep sleep" if it has not been moved for more than 15 minutes over the past 7 days (the exact duration is secondary; the crucial point is simply that this deep-sleep state occurs).

To make this state more transparent to users, we should display the corresponding wake-up commands sent from the Stellantis backend servers to the vehicle. If the vehicle is indeed in deep sleep (having not moved for some time), this wake-up command times out (a scenario we already track in the command history).

This PR also updates the EN.json and DE.json files accordingly. (EDIT: it covers all *.json files now)

This PR has *not* yet updated the README.md (specifically the error messages section) to explain the situation to users. Please let me know if I should include this in the PR as well.