### PR TITLE
Fix: reschedule OAuth/MQTT token refresh after unexpected errors

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -535,6 +535,9 @@ class StellantisVehicles(StellantisOauth):
         except RateLimitException:
             _LOGGER.warning("Rate limit exceeded, retry after 30 mins or check logs and restart integration")
             next_run = get_datetime() + timedelta(minutes=30)
+        except Exception as e:
+            _LOGGER.error(f"Unexpected error during OAuth token refresh, rescheduling in 5 min: {e}")
+            next_run = get_datetime() + timedelta(minutes=5)
         _LOGGER.debug(f"Current time: {get_datetime()}")
         _LOGGER.debug(f"Next refresh: {next_run}")
         next_job = HassJob(self.scheduled_oauth_token_refresh, f"{DOMAIN} refresh oauth token: {next_run}", cancel_on_shutdown=True)
@@ -671,6 +674,9 @@ class StellantisVehicles(StellantisOauth):
             _LOGGER.error("MQTT authentication error. To enable remote commands again please reconfigure the integration")
             _LOGGER.debug("---------- END scheduled_mqtt_token_refresh")
             return
+        except Exception as e:
+            _LOGGER.error(f"Unexpected error during MQTT token refresh, rescheduling in 5 min: {e}")
+            next_run = get_datetime() + timedelta(minutes=5)
         _LOGGER.debug(f"Current time: {get_datetime()}")
         _LOGGER.debug(f"Next refresh: {next_run}")
         next_job = HassJob(self.scheduled_mqtt_token_refresh, f"{DOMAIN} refresh mqtt token: {next_run}", cancel_on_shutdown=True)


### PR DESCRIPTION
scheduled_oauth_token_refresh and scheduled_mqtt_token_refresh only caught ComunicationError/RateLimitException (and ConfigException for MQTT). Any other exception from refresh_token_request / refresh_mqtt_token_request (e.g. a transient Stellantis server_error) escaped before the async_track_point_in_time rescheduling call ran, permanently killing the refresh loop until a full HA restart.

Add a catch-all Exception handler that logs and retries in 5 minutes in both functions, so the loop always reschedules itself. The existing @rate_limit decorators on the underlying request methods already prevent tight retry loops.

Fixes #526