### PR TITLE
Fix error handling and timezone comparison in _async_update_data

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, UTC
 import json
 from copy import deepcopy
 
-from homeassistant.helpers.update_coordinator import ( CoordinatorEntity, DataUpdateCoordinator )
+from homeassistant.helpers.update_coordinator import ( CoordinatorEntity, DataUpdateCoordinator, UpdateFailed )
 from homeassistant.components.device_tracker import ( SourceType, TrackerEntity )
 from homeassistant.components.sensor import RestoreSensor
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -57,23 +57,31 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         _LOGGER.debug(self._config)
         try:
             new_data = await self._stellantis.get_vehicle_status(self._vehicle)
-            if "updatedAt" in new_data and "updatedAt" in self._data:
-                try:
-                    current_dt = datetime.fromisoformat(self._data["updatedAt"])
-                    new_dt = datetime.fromisoformat(new_data["updatedAt"])
-                except ValueError:
-                    _LOGGER.debug("Invalid updatedAt values, proceeding with update without timestamp comparison")
-                else:
-                    if new_dt <= current_dt:
-                        _LOGGER.debug("API did not return updated vehicle data, skipping sensor update")
-                        _LOGGER.debug("---------- END _async_update_data")
-                        return
-            self._data = new_data
         except ConfigEntryAuthFailed:
             _LOGGER.debug("---------- END _async_update_data")
             raise
-        except Exception:
-            pass
+        except Exception as err:
+            _LOGGER.debug("Error communicating with Stellantis API: %s", err)
+            _LOGGER.debug("---------- END _async_update_data")
+            raise UpdateFailed("Error communicating with Stellantis API") from err
+
+        if "updatedAt" in new_data and "updatedAt" in self._data:
+            try:
+                current_dt = datetime.fromisoformat(self._data["updatedAt"])
+                new_dt = datetime.fromisoformat(new_data["updatedAt"])
+                if current_dt.tzinfo is None:
+                    current_dt = current_dt.replace(tzinfo=UTC)
+                if new_dt.tzinfo is None:
+                    new_dt = new_dt.replace(tzinfo=UTC)
+            except (ValueError, TypeError):
+                _LOGGER.debug("Invalid updatedAt values, proceeding with update without timestamp comparison")
+            else:
+                if new_dt <= current_dt:
+                    _LOGGER.debug("API did not return updated vehicle data, skipping sensor update")
+                    _LOGGER.debug("---------- END _async_update_data")
+                    return
+
+        self._data = new_data
         await self.after_async_update_data()
         _LOGGER.debug("---------- END _async_update_data")
 


### PR DESCRIPTION
This PR fixes the situations described in #544.

- Normalize `updatedAt` timestamps to UTC-aware `datetime` objects before comparing them, fixing a `TypeError: can't compare offset-naive and offset-aware datetimes` that could be raised when one timestamp carries a UTC offset (`Z` / `+00:00`) and the other doesn't.
- Catch `TypeError` alongside `ValueError` when parsing `updatedAt`, so a non-string value degrades gracefully (skip the staleness comparison, proceed with the update) instead of being swallowed further up.
- Replace the bare `except Exception: pass` with `raise UpdateFailed(...)`, so unexpected API errors (timeouts, connection issues, 5xx, unexpected responses) are properly surfaced to the coordinator instead of being silently discarded. This lets `last_update_success` and entity availability reflect real failures, and lets Home Assistant log and retry as designed.
- Keep the raised `UpdateFailed` message generic and log the actual exception only at debug level, avoiding exposure of exception details that could (in some error paths) include request URLs with sensitive query parameters.


