### PR TITLE
Add optional binary sensors for "open/closed" status for doors (disabled by default)

### DIFF
--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -318,6 +318,41 @@ BINARY_SENSORS_DEFAULT = {
         "device_class" : BinarySensorDeviceClass.LOCK,
         "on_value": "Unlocked"
     },
+    "door_trunk" : {
+        "icon" : "mdi:car-back",
+        "value_map" : ["doorsState", "opening", {"identifier":"Trunk"}, "state"],
+        "updated_at_map" : ["doorsState", "createdAt"],
+        "device_class" : BinarySensorDeviceClass.DOOR,
+        "on_value": "Open"
+    },
+    "door_driver" : {
+        "icon" : "mdi:car-door",
+        "value_map" : ["doorsState", "opening", {"identifier":"Driver"}, "state"],
+        "updated_at_map" : ["doorsState", "createdAt"],
+        "device_class" : BinarySensorDeviceClass.DOOR,
+        "on_value": "Open"
+    },
+    "door_passenger" : {
+        "icon" : "mdi:car-door",
+        "value_map" : ["doorsState", "opening", {"identifier":"Passenger"}, "state"],
+        "updated_at_map" : ["doorsState", "createdAt"],
+        "device_class" : BinarySensorDeviceClass.DOOR,
+        "on_value": "Open"
+    },
+    "door_rear_left" : {
+        "icon" : "mdi:car-door",
+        "value_map" : ["doorsState", "opening", {"identifier":"RearLeft"}, "state"],
+        "updated_at_map" : ["doorsState", "createdAt"],
+        "device_class" : BinarySensorDeviceClass.DOOR,
+        "on_value": "Open"
+    },
+    "door_rear_right" : {
+        "icon" : "mdi:car-door",
+        "value_map" : ["doorsState", "opening", {"identifier":"RearRight"}, "state"],
+        "updated_at_map" : ["doorsState", "createdAt"],
+        "device_class" : BinarySensorDeviceClass.DOOR,
+        "on_value": "Open"
+    },
     "battery_plugged" : {
         "icon" : "mdi:power-plug-battery",
         "value_map" : ["energies", {"type":"Electric"}, "extension", "electric", "charging", "plugged"],

--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -259,6 +259,21 @@
       "doors": {
         "name": "Türen"
       },
+      "door_trunk": {
+        "name": "Kofferraum"
+      },
+      "door_driver": {
+        "name": "Fahrertür"
+      },
+      "door_passenger": {
+        "name": "Beifahrertür"
+      },
+      "door_rear_left": {
+        "name": "Hintere Tür links"
+      },
+      "door_rear_right": {
+        "name": "Hintere Tür rechts"
+      },
       "battery_plugged": {
         "name": "Ladekabel angeschlossen"
       },

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -260,6 +260,21 @@
       "doors": {
         "name": "Doors"
       },
+      "door_trunk": {
+        "name": "Trunk"
+      },
+      "door_driver": {
+        "name": "Driver door"
+      },
+      "door_passenger": {
+        "name": "Passenger door"
+      },
+      "door_rear_left": {
+        "name": "Rear left door"
+      },
+      "door_rear_right": {
+        "name": "Rear right door"
+      },
       "battery_plugged": {
         "name": "Battery plugged"
       },


### PR DESCRIPTION
Minor change to support #216 