### PR TITLE
Improvement: Staggered execution of periodic API polls across multiple vehicles

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -18,7 +18,8 @@ from .const import (
     INTEGRATION_VERSION,
     PLATFORMS,
     OTP_FILENAME,
-    FIELD_NOTIFICATIONS
+    FIELD_NOTIFICATIONS,
+    UPDATE_INTERVAL
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,9 +48,13 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
         await stellantis.hass_notify("no_vehicles_found")
         await stellantis.close_session()
 
-    for vehicle in vehicles:
+    for index, vehicle in enumerate(vehicles):
         coordinator = await stellantis.async_get_coordinator(vehicle)
         await coordinator.async_config_entry_first_refresh()
+        if index and len(vehicles) > 1:
+            # Spread the periodic polls of multiple vehicles across the interval
+            # instead of hitting the API for all of them at the same instant.
+            coordinator.stagger_first_poll(index * UPDATE_INTERVAL / len(vehicles))
 
     url = f"/stellantis_vehicles/{INTEGRATION_VERSION}/stellantis-vehicle-card.js"
     if url not in hass.data["frontend_extra_module_url"].urls:

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -47,6 +47,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         self._last_trip = None
 #        self._total_trip = None
         self._manage_charge_limit_sent = False
+        self._phase_offset = 0
 
         if self._stellantis.logger_filter:
             _LOGGER.addFilter(self._stellantis.logger_filter)
@@ -55,6 +56,13 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         """ Update vehicle data from Stellantis. """
         _LOGGER.debug("---------- START _async_update_data")
         _LOGGER.debug(self._config)
+
+        if self._phase_offset:
+            # The one-time startup stagger has been consumed, go back to the
+            # normal cadence (a number_refresh_interval override, if any, is
+            # re-applied just below).
+            self._phase_offset = 0
+            self.update_interval = timedelta(seconds=UPDATE_INTERVAL)
 
         refresh_interval = self._sensors.get("number_refresh_interval")
         if refresh_interval and refresh_interval > 0 and refresh_interval != self.update_interval.total_seconds():
@@ -89,6 +97,15 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         self._data = new_data
         await self.after_async_update_data()
         _LOGGER.debug("---------- END _async_update_data")
+
+    def stagger_first_poll(self, offset_seconds):
+        """ Push this vehicle's next poll back once so several vehicles do not all
+        poll at the same instant after a restart. """
+        offset_seconds = int(offset_seconds)
+        if offset_seconds <= 0:
+            return
+        self._phase_offset = offset_seconds
+        self.update_interval = timedelta(seconds=UPDATE_INTERVAL + offset_seconds)
 
     def get_translation(self, path, default = None):
         """ Get translation from path. """


### PR DESCRIPTION
_Based on the feedback in https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/discussions/543#discussioncomment-18193659_

## As of today

`async_setup_entry` creates every vehicle's coordinator and runs its first
refresh back-to-back, all with the same `UPDATE_INTERVAL`. The coordinators
therefore stay phase-locked and, on a multi-vehicle account, poll the Stellantis
API for all vehicles at (nearly) the same instant on every cycle. This bursts
the API and makes debug logs harder to read (per-vehicle events are interleaved).

## Change

- `__init__.py::async_setup_entry`: `enumerate(vehicles)`; after the first
  refresh, vehicle *i* (`i > 0`, and only when there is more than one vehicle)
  gets a one-time phase shift of `i * UPDATE_INTERVAL / len(vehicles)` seconds
  via `coordinator.stagger_first_poll(...)`.
- `base.py`:
  - `stagger_first_poll(offset_seconds)` pushes the next poll back once by
    lengthening `update_interval` for a single cycle.
  - `_async_update_data` consumes the offset on the next run and restores the
    normal cadence (a `number_refresh_interval` override is re-applied right
    after, unchanged).

Only the phase changes; the polling rate is unchanged, and per-vehicle `number_refresh_interval` still works.

## Behaviour

| | Before | After (2 vehicles) |
|---|---|---|
| Poll timing | both vehicles polled together every cycle | ~30 s apart |
| After restart | phase-locked again | re-staggered automatically |