### PR TITLE
Improvement: Quieten the "Engine status unchanged or not relevant" last-trip log line

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -288,8 +288,8 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         if new_engine_status == "Stop" and current_engine_status not in (None, "Stop"):
             _LOGGER.debug("Engine status changed from %s to %s, fetching last trip data", current_engine_status, new_engine_status)
             await self.get_vehicle_last_trip()
-        else:
-            _LOGGER.debug("Engine status unchanged or not relevant for trip data fetch: %s vs %s", current_engine_status, new_engine_status)
+        elif new_engine_status == "Stop":
+            _LOGGER.debug("No last-trip fetch needed (engine %s -> Stop)", current_engine_status)
 
     async def get_vehicle_last_trip(self):
         """ Get last trip from Stellantis. """


### PR DESCRIPTION
_Based on the feedback in https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/discussions/543#discussioncomment-18193659_

## As is today

`after_async_update_data` logs `Engine status unchanged or not relevant for trip data fetch: <a> vs <b>` on **every** normal poll cycle. It is by far the most frequent line in a debug log and its wording ("unchanged or not relevant") reads like a warning even though nothing is wrong.

## Change

`base.py`: the `else` branch is replaced by `elif new_engine_status == "Stop"` with a neutral message `No last-trip fetch needed (engine <prev> -> Stop)`.

- When the engine is running or its state is unknown (after HA restart) nothing is logged at all.
- When the engine is already stopped (`Stop -> Stop`) a short, neutral line is logged instead of the old one.

## Behaviour

| Cycle | Status | Before | After |
|---|---|---|---|
| `None -> Stop` | HA just started | `... unchanged or not relevant ...` | `No last-trip fetch needed (engine None -> Stop)` |
| `Stop -> Stop` | parked | `... unchanged or not relevant ...` | `No last-trip fetch needed (engine Stop -> Stop)` |
| `StartUp -> StartUp` | on the way | `... unchanged or not relevant ...` | (nothing) |
| `StartUp -> Stop` | engine just stopped | `Engine status changed ...` | `Engine status changed ...` (unchanged) |
