### PR TITLE
Improvement: Isolate per-vehicle config under a `vehicles` sub-node so pruning is safe

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -240,6 +240,41 @@ async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):
         hass.config_entries.async_update_entry(config, data=new_data, version=target_version, minor_version=target_minor_version)
         _LOGGER.debug("Migration to configuration version %s.%s successful", config.version, config.minor_version)
 
+    # Bumped past the current INTEGRATION_VERSION (20260801) on purpose: betas
+    # already shipped as 20260801, so this migration must still trigger for
+    # entries already sitting at that version. Aligns with INTEGRATION_VERSION
+    # once the 2026.8.2 stable ships.
+    target_version = 20260802
+    if config.version < target_version or "vehicles" not in config.data:
+        _LOGGER.debug("Migrating configuration from version %s.%s", config.version, config.minor_version)
+        data = dict(config.data)
+
+        def update_data(data):
+            # Move all flat per-vehicle nodes under a dedicated "vehicles" sub-node
+            # so the stale-vehicle prune process can no longer touch other config data.
+            vehicles = dict(data.get("vehicles", {}))
+            reserved = ("oauth", "mqtt", "vehicles")
+            for key in list(data.keys()):
+                value = data[key]
+                if key in reserved or not isinstance(value, dict):
+                    continue
+                # Extra safety: only treat entries that look like a VIN (17 alphanumeric chars).
+                if len(key) == 17 and key.isalnum():
+                    moved = data.pop(key)
+                    # A "vehicles" entry written by a newer build before this
+                    # migration ran wins per key over the older flat data.
+                    vehicles[key] = {**moved, **vehicles.get(key, {})}
+            data["vehicles"] = vehicles
+            return data
+
+        new_data = await hass.async_add_executor_job(update_data, data)
+        if INTEGRATION_IS_BETA:
+            # Leave the entry version alone on beta (see the global update below)
+            hass.config_entries.async_update_entry(config, data=new_data)
+        else:
+            hass.config_entries.async_update_entry(config, data=new_data, version=target_version, minor_version=1)
+        _LOGGER.debug("Migration to configuration version %s.%s successful", config.version, config.minor_version)
+
     # template for future migration steps
     target_version = 20260702   # to be updated with the next version number
     if config.version < target_version:

--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -16,6 +16,7 @@ from .config_flow import StellantisVehiclesConfigFlow
 from .const import (
     DOMAIN,
     INTEGRATION_VERSION,
+    INTEGRATION_IS_BETA,
     PLATFORMS,
     OTP_FILENAME,
     FIELD_NOTIFICATIONS
@@ -248,11 +249,17 @@ async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):
             # migration logic here
             return data
         new_data = await hass.async_add_executor_job(update_data, data)
-        hass.config_entries.async_update_entry(config, data=new_data, version=target_version, minor_version=1)
+        if INTEGRATION_IS_BETA:
+            # Leave the entry version alone on beta (see the global update below)
+            hass.config_entries.async_update_entry(config, data=new_data)
+        else:
+            hass.config_entries.async_update_entry(config, data=new_data, version=target_version, minor_version=1)
         _LOGGER.debug("Migration to configuration version %s.%s successful", config.version, config.minor_version)
 
-    # Global update of versions
-    if config.version < INTEGRATION_VERSION:
+    # Global update of versions - only pull the entry version forward on real
+    # (non-beta) releases, so beta iterations that share a version number keep
+    # re-triggering their own migration steps until the stable release ships.
+    if config.version < INTEGRATION_VERSION and not INTEGRATION_IS_BETA:
         _LOGGER.debug("Entry version updated from %s.%s to %s.1", config.version, config.minor_version, INTEGRATION_VERSION)
         hass.config_entries.async_update_entry(config, version=INTEGRATION_VERSION, minor_version=1)
 

--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -41,6 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
         vehicles = {}
 
     if vehicles:
+        stellantis.prune_stored_vehicle_configs({vehicle["vin"] for vehicle in vehicles})
         await hass.config_entries.async_forward_entry_setups(config, PLATFORMS)
     else:
         _LOGGER.warning("No vehicles found for this account")

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -9,6 +9,8 @@ DOMAIN = "stellantis_vehicles"
 
 with open(os.path.dirname(os.path.abspath(__file__)) + "/manifest.json", "r") as f:
     manifest = json.load(f)
+    # A pre-release manifest version carries a "-beta.N" suffix (e.g. "2026.8.1-beta.3").
+    INTEGRATION_IS_BETA = "-beta" in manifest["version"]
     versions = manifest["version"].split("-beta")[0].split(".")
     minor = int(versions[1])
     if minor < 10:

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -173,6 +173,10 @@ class StellantisBase:
         for key in vehicle:
             string = string.replace("{#" + key + "#}", str(vehicle[key]))
         for key, value in self._config.items():
+            # Per-vehicle stored config is never a placeholder source and its
+            # nested dict-of-dicts shape would not stringify usefully here.
+            if key == "vehicles":
+                continue
             if isinstance(value, dict):
                 for subkey, subvalue in value.items():
                     string = string.replace("{#" + key + "|" + subkey + "#}", str(subvalue))
@@ -456,18 +460,33 @@ class StellantisVehicles(StellantisOauth):
             return self._entry.data[config]
         return None
 
+    def get_vehicles_stored_config(self):
+        """Return the per-vehicle stored config sub-node, keyed by VIN."""
+        return self.get_stored_config("vehicles") or {}
+
     def update_vehicle_stored_config(self, vin, key, value):
-        data = self.get_stored_config(vin)
-        if not data:
-            data = {}
-        data[key] = value
-        self.update_stored_config(vin, data)
+        vehicles = deepcopy(self.get_vehicles_stored_config())
+        vehicles.setdefault(vin, {})[key] = value
+        self.update_stored_config("vehicles", vehicles)
+        self._config["vehicles"] = deepcopy(vehicles)
 
     def get_vehicle_stored_config(self, vin, key):
-        data = self.get_stored_config(vin)
-        if data and key in data:
-            return data[key]
+        vehicle = self.get_vehicles_stored_config().get(vin)
+        if vehicle and key in vehicle:
+            return vehicle[key]
         return None
+
+    def prune_stored_vehicle_configs(self, live_vins):
+        """Drop per-vehicle stored config for vehicles no longer on the account."""
+        vehicles = self.get_vehicles_stored_config()
+        stale = [vin for vin in vehicles if vin not in live_vins]
+        if not stale:
+            return []
+        new_vehicles = {vin: deepcopy(value) for vin, value in vehicles.items() if vin not in stale}
+        self.update_stored_config("vehicles", new_vehicles)
+        self._config["vehicles"] = deepcopy(new_vehicles)
+        _LOGGER.info("Removed stored config for vehicles no longer on the account: %s", ", ".join(stale))
+        return stale
 
     def async_get_coordinator_by_vin(self, vin):
         if vin in self._coordinator_dict:


### PR DESCRIPTION
_Based on the feedback in https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/discussions/543#discussioncomment-18193659_

⚠️ **Maintainer heads-up:** 
  >`target_version` is `20260802`, i.e. **one ahead of the current `INTEGRATION_VERSION` (20260801)**.
  >This is deliberate – betas already shipped as `20260801`, so a step keyed to `< 20260801` would never fire for those entries. It lines up with `INTEGRATION_VERSION` automatically once the manifest is bumped to `2026.8.2` – **and that bump is required for this migration to run on existing `20260801` entries**, since Home Assistant only calls `async_migrate_entry` while `entry.version < INTEGRATION_VERSION`.
  >
  >Ship this together with the `2026.8.2(-beta.x)` version bump. Entries on older versions (pre-`20260801`) migrate as soon as this lands.

## Problem

Per-vehicle settings (`number_battery_charging_limit`, `number_refresh_interval`, the `switch_*` toggles, `text_abrp_token`) are stored under a **flat VIN key** in `config_entry.data` by `update_vehicle_stored_config`, right next to the infrastructure keys (`oauth`, `mqtt`, `customer_id`, `basic_token`, …).

Two issues follow from that layout:

1. Nothing reconciles `config_entry.data` against the live account. When a vehicle is sold / unpaired its VIN key is never removed – it stays in `config_entry.data` (and in the in-memory `self._config`) forever and shows up in every debug log dump, even after a restart.
2. Cleaning that up in place is fragile: because per-vehicle data sits at the same level as `oauth`, `mqtt`, `customer_id`, … a pruner can only recognise a vehicle entry by shape ("a dict that isn't a known infrastructure key"), and every future dict-shaped key would have to be added to that exclusion list or risk being deleted on the next setup.

## Change

- **New `vehicles` sub-node.** All per-vehicle stored config now lives under `config_entry.data["vehicles"][<vin>]`. `update_vehicle_stored_config` / `get_vehicle_stored_config` and the new `get_vehicles_stored_config` helper read/write that node instead of a flat VIN key.
- **`prune_stored_vehicle_configs(live_vins)`** (new) iterates *only* `config_entry.data["vehicles"]`, drops VINs not in `live_vins` with a single `async_update_entry`, mirrors the result into `self._config["vehicles"]`, and logs once at `INFO`. Exact VIN match, no shape-guessing and no exclusion list – it cannot touch any other config data.
- **`replace_placeholders`** skips the `vehicles` node (nested dict-of-dicts, not a placeholder source).
- `async_setup_entry` calls `prune_stored_vehicle_configs` right after a successful `get_user_vehicles()`, inside the existing `if vehicles:` branch, so it never runs on the error path (empty result / fetch failure).
- **Beta guard (`INTEGRATION_IS_BETA`, from `-beta` in the manifest version).** `INTEGRATION_VERSION` is derived from the manifest version with the `-beta.N` suffix stripped, so every beta iteration of a release shares one version number. The global "pull entry version forward" step, plus the version bump in the new step and in the migration-step template, are skipped on beta builds, so a later beta can still re-run a step it keyed to that shared number. The stable release advances the entry version.
- **`async_migrate_entry` – new step (`target_version = 20260802`).** Moves any pre-existing flat VIN key into `data["vehicles"]`. VIN detection = 17 alphanumeric chars; `oauth`/`mqtt`/`vehicles` are reserved. If a `vehicles` entry for that VIN already exists (e.g. written by a newer build before the migration ran), it is merged per key with the existing values winning. Idempotent: the step is also entered when `"vehicles" not in config.data`, and re-writing the already-migrated data is a no-op in `async_update_entry`. Per the beta guard above, the entry version is only advanced on the stable release; until then the step re-runs (harmlessly) on every start.

## Behaviour

| | Before | After |
|---|---|---|
| Per-vehicle settings location | flat VIN key in `config_entry.data` | `config_entry.data["vehicles"][<vin>]` |
| Sold vehicle's stored settings | kept forever | removed on the next setup after it leaves the account |
| Pruning a stale VIN | not possible without a fragile heuristic | exact match inside `vehicles` |
| Debug log dump | lists the dead VIN's config | clean |

## Scope / non-goals

- Config data only. Does **not** delete the orphaned device/entities from the registries or the leftover `www/<domain>/<customer>/<vin>.png` – the former is a separate concern, the latter is already cleaned when the whole entry is removed (`async_remove_entry`). Could be a follow-up.
- Migration timing: pre-`20260801` entries migrate as soon as this lands; existing `20260801` beta entries only once the manifest is bumped to `2026.8.2(-beta.x)` (see the maintainer heads-up above).
