### PR TITLE
Improvement: Detect an unpaired vehicle without a restart

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -5,7 +5,7 @@ import os
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import issue_registry
+from homeassistant.helpers import issue_registry, device_registry as dr
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
 
@@ -79,6 +79,32 @@ async def async_unload_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(config.entry_id)
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config: ConfigEntry, device: dr.DeviceEntry
+) -> bool:
+    """Allow deleting a device only when its vehicle is no longer on the account.
+
+    Without this the UI offers no way to remove a vehicle's device, so the
+    device and its (now unavailable) entities linger after the vehicle is
+    unpaired. A device for a vehicle still returned by the account cannot be
+    deleted - it would just be recreated on the next refresh.
+    """
+    stellantis = hass.data.get(DOMAIN, {}).get(config.entry_id)
+    if stellantis is None:
+        return True
+    try:
+        known_vins = {
+            vehicle["vin"] for vehicle in await stellantis.get_user_vehicles()
+        }
+    except Exception as err:  # noqa: BLE001 - never block manual cleanup on an API error
+        _LOGGER.warning("Could not verify account vehicles before device removal: %s", err)
+        known_vins = set()
+    return not any(
+        identifier[0] == DOMAIN and identifier[1] in known_vins
+        for identifier in device.identifiers
+    )
 
 
 async def async_remove_entry(hass: HomeAssistant, config: ConfigEntry) -> None:

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -17,6 +17,7 @@ from homeassistant.core import callback, HomeAssistant
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.const import ( STATE_UNAVAILABLE, STATE_UNKNOWN, STATE_ON, STATE_OFF)
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 
 from .utils import ( time_from_pt_string, get_datetime, date_from_pt_string, time_from_string, rate_limit )
 
@@ -26,6 +27,7 @@ from .const import (
     VEHICLE_TYPE_ELECTRIC,
     VEHICLE_TYPE_HYBRID,
     UPDATE_INTERVAL,
+    EMPTY_STATUS_LIMIT,
     KWH_CORRECTION
 )
 
@@ -49,6 +51,8 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         self._manage_charge_limit_sent = False
         self._phase_offset = 0
         self._privacy_full_logged = False
+        self._empty_status_count = 0
+        self._vehicle_removed = False
 
         if self._stellantis.logger_filter:
             _LOGGER.addFilter(self._stellantis.logger_filter)
@@ -79,7 +83,13 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("---------- END _async_update_data")
             raise UpdateFailed("Error communicating with Stellantis API") from err
 
-        if new_data:
+        if not new_data:
+            self._empty_status_count += 1
+            if self._empty_status_count >= EMPTY_STATUS_LIMIT and not self._vehicle_removed:
+                await self._reconcile_vehicle()
+        else:
+            self._empty_status_count = 0
+            self._clear_vehicle_removed()
             self._log_privacy_mode(new_data.get("privacy", {}).get("state"))
 
         if "updatedAt" in new_data and "updatedAt" in self._data:
@@ -120,6 +130,39 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         elif not active and self._privacy_full_logged:
             self._privacy_full_logged = False
             _LOGGER.info("Private mode is disabled on vehicle %s, live data updates resumed", self._vehicle["vin"])
+
+    async def _reconcile_vehicle(self):
+        """ Re-fetch the account vehicle list to check whether this vehicle was unpaired. """
+        vin = self._vehicle["vin"]
+        try:
+            live = await self._stellantis.get_user_vehicles(force=True)
+        except Exception as err:
+            _LOGGER.debug("Could not refresh the vehicle list for %s: %s", vin, err)
+            return
+        live_vins = {vehicle.get("vin") for vehicle in live}
+        if not live_vins or vin in live_vins:
+            # List unavailable or the vehicle is still there: keep polling.
+            self._empty_status_count = 0
+            return
+        self._vehicle_removed = True
+        _LOGGER.warning("Vehicle %s is no longer linked to this Stellantis account", vin)
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            f"vehicle_removed_{vin}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="vehicle_removed",
+            translation_placeholders={"vin": vin},
+        )
+
+    def _clear_vehicle_removed(self):
+        """ Vehicle answered again: drop the repair issue and log the recovery once. """
+        if not self._vehicle_removed:
+            return
+        self._vehicle_removed = False
+        _LOGGER.info("Vehicle %s is reachable again", self._vehicle["vin"])
+        ir.async_delete_issue(self._hass, DOMAIN, f"vehicle_removed_{self._vehicle['vin']}")
 
     def get_translation(self, path, default = None):
         """ Get translation from path. """

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -126,6 +126,10 @@ PLATFORMS = [
 
 UPDATE_INTERVAL = 60 # seconds
 
+# Consecutive empty vehicle-status responses before the account vehicle list is
+# re-fetched to check whether the vehicle was unpaired.
+EMPTY_STATUS_LIMIT = 3
+
 VEHICLE_TYPE_ELECTRIC = "Electric"
 VEHICLE_TYPE_HYBRID = "Hybrid"
 VEHICLE_TYPE_THERMIC = "Thermic"

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -589,8 +589,12 @@ class StellantisVehicles(StellantisOauth):
         self.update_stored_config("oauth", new_config)
         _LOGGER.debug("---------- END refresh_token_request")
 
-    async def get_user_vehicles(self):
+    async def get_user_vehicles(self, force=False):
         _LOGGER.debug("---------- START get_user_vehicles")
+        if force:
+            # Drop the cache so the account vehicle list is fetched again, e.g. to
+            # confirm a vehicle was unpaired without restarting Home Assistant.
+            self._vehicles = []
         if not self._vehicles:
             url = self.apply_query_params(CAR_API_VEHICLES_URL, CLIENT_ID_QUERY_PARAMS)
             headers = self.apply_dict_params(CAR_API_HEADERS)

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -403,7 +403,7 @@
   "issues": {
     "vehicle_removed": {
       "title": "Vehicle {vin} was removed from your account",
-      "description": "Home Assistant can no longer reach vehicle `{vin}` through the Stellantis API, and it is no longer listed on your Stellantis account. This usually means the vehicle was sold or unpaired.\n\nTo resolve this:\n1. Open **Settings > Devices & services > Stellantis Vehicles**.\n2. Open the device for this vehicle and select **Delete**.\n3. Restart Home Assistant.\n\nThis warning disappears once the vehicle is removed."
+      "description": "Home Assistant can no longer reach vehicle `{vin}` through the Stellantis API, and it is no longer listed on your Stellantis account. This usually means the vehicle was sold or unpaired.\n\n**Warning:** Deleting the device also permanently deletes **all of its entities**, and with them **all short- and long-term statistics** collected for this vehicle (for example energy, mileage, and battery history). This data cannot be recovered. If you want to keep it, export or back it up before you continue.\n\nTo resolve this:\n1. Open **Settings > Devices & services > Stellantis Vehicles**.\n2. Open the device for this vehicle and select **Delete**.\n3. Restart Home Assistant.\n\nThis warning disappears once the vehicle is removed."
     }
   },
   "selector": {

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -400,6 +400,12 @@
     "command_error_title": "Command",
     "command_error_message": "The command was not sent correctly"
   },
+  "issues": {
+    "vehicle_removed": {
+      "title": "Vehicle {vin} was removed from your account",
+      "description": "Home Assistant can no longer reach vehicle `{vin}` through the Stellantis API, and it is no longer listed on your Stellantis account. This usually means the vehicle was sold or unpaired.\n\nTo resolve this:\n1. Open **Settings > Devices & services > Stellantis Vehicles**.\n2. Open the device for this vehicle and select **Delete**.\n3. Restart Home Assistant.\n\nThis warning disappears once the vehicle is removed."
+    }
+  },
   "selector": {
     "reconfigure": {
       "options": {


### PR DESCRIPTION
_Based on the feedback in https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/discussions/543#discussioncomment-18193659_

## Problem

When a vehicle is removed from the Stellantis account, its `/status` endpoint returns `404 / 40400` and the integration keeps polling and warning about it until Home Assistant is restarted. Only the restart re-runs `get_user_vehicles` and notices the vehicle is gone. There is no runtime reconciliation.

## Root cause

`get_user_vehicles` caches the account vehicle list in `self._vehicles` and never refetches it for the lifetime of the config entry (`if not self._vehicles:`).

## Change

- `get_user_vehicles(force=False)`: with `force=True` the cache is dropped and the account vehicle list is fetched again.
- `StellantisVehicleCoordinator`:
  - counts consecutive empty vehicle-status responses;
  - after `EMPTY_STATUS_LIMIT` (3) it calls `get_user_vehicles(force=True)` once and, if this vehicle's VIN is no longer on the account, raises a repair issue (`vehicle_removed`) and stops re-checking;
  - if the list still contains the VIN (or could not be fetched) it resets the counter and keeps polling;
  - a later non-empty response clears the issue and logs the recovery once.
- `EMPTY_STATUS_LIMIT` added to `const.py`; `issues.vehicle_removed` added to `translations/en.json` (other locales left to their maintainers).

This is intentionally conservative: it only surfaces the removal (repair issue + entities go stale). It does **not** unsubscribe MQTT, tear down the coordinator or delete the device/entities at runtime – an HA restart still performs that cleanup.

## Behaviour

| | Before | After |
|---|---|---|
| Removal noticed | only on next HA restart | within a few poll cycles |
| User signal | none | Repairs issue with removal instructions |
| Extra API calls | none | one vehicle-list fetch after 3 empty status responses, then none until it recovers |

## Scope / non-goals

- No runtime teardown of MQTT / coordinator / registry entries.
- Reacts to *empty* status responses; it does not itself change how an empty response is handled elsewhere.

## Screenshots

### Repair
<img width="649" height="140" alt="image" src="https://github.com/user-attachments/assets/2ba1479c-917a-4ce4-88c3-30ab7a5f08bf" />

### Repair Details
<img width="603" height="429" alt="image" src="https://github.com/user-attachments/assets/286ee81f-21bb-4b7d-b34b-de3aa1076d1e" />
