### PR TITLE
Fix the privacy binary sensor and log private mode once

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -48,6 +48,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
 #        self._total_trip = None
         self._manage_charge_limit_sent = False
         self._phase_offset = 0
+        self._privacy_full_logged = False
 
         if self._stellantis.logger_filter:
             _LOGGER.addFilter(self._stellantis.logger_filter)
@@ -78,6 +79,9 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("---------- END _async_update_data")
             raise UpdateFailed("Error communicating with Stellantis API") from err
 
+        if new_data:
+            self._log_privacy_mode(new_data.get("privacy", {}).get("state"))
+
         if "updatedAt" in new_data and "updatedAt" in self._data:
             try:
                 current_dt = datetime.fromisoformat(self._data["updatedAt"])
@@ -106,6 +110,16 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             return
         self._phase_offset = offset_seconds
         self.update_interval = timedelta(seconds=UPDATE_INTERVAL + offset_seconds)
+
+    def _log_privacy_mode(self, state):
+        """ Log once when Stellantis private mode starts or stops pausing live data. """
+        active = state == "Full"
+        if active and not self._privacy_full_logged:
+            self._privacy_full_logged = True
+            _LOGGER.info("Private mode is enabled on vehicle %s, Stellantis has paused live data updates", self._vehicle["vin"])
+        elif not active and self._privacy_full_logged:
+            self._privacy_full_logged = False
+            _LOGGER.info("Private mode is disabled on vehicle %s, live data updates resumed", self._vehicle["vin"])
 
     def get_translation(self, path, default = None):
         """ Get translation from path. """

--- a/custom_components/stellantis_vehicles/binary_sensor.py
+++ b/custom_components/stellantis_vehicles/binary_sensor.py
@@ -32,7 +32,8 @@ async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> No
                         key = key,
                         translation_key = key,
                         icon = default_value.get("icon", None),
-                        device_class = default_value.get("device_class", None)
+                        device_class = default_value.get("device_class", None),
+                        entity_category = default_value.get("entity_category", None)
                     )
                     entities.extend([StellantisBaseBinarySensor(coordinator, description, default_value.get("value_map"), default_value.get("updated_at_map"), default_value.get("on_value", None))])
 

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from homeassistant.const import ( UnitOfTemperature, UnitOfLength, PERCENTAGE, UnitOfEnergy, UnitOfSpeed, UnitOfVolume )
+from homeassistant.const import ( UnitOfTemperature, UnitOfLength, PERCENTAGE, UnitOfEnergy, UnitOfSpeed, UnitOfVolume, EntityCategory )
 from homeassistant.components.sensor.const import ( SensorDeviceClass, SensorStateClass )
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
@@ -412,11 +412,11 @@ BINARY_SENSORS_DEFAULT = {
         "on_value": "Active"
     },
     "privacy" : {
-        "icon" : "mdi:alarm-light",
+        "icon" : "mdi:eye-off",
         "value_map" : ["privacy", "state"],
         "updated_at_map" : ["privacy", "createdAt"],
-        "device_class" : BinarySensorDeviceClass.LOCK,
-        "on_value": "None"
+        "entity_category" : EntityCategory.DIAGNOSTIC,
+        "on_value": "Full"
     },
     "daylight" : {
         "icon" : "mdi:weather-sunny",


### PR DESCRIPTION
_Based on the feedback in https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/discussions/543#discussioncomment-18193659_

## Problem

When the vehicle is put into full private mode (e.g. via the in-car screen or a
"prepare for change of ownership" reset), the Stellantis API returns
`privacy.state: "Full"` and stops refreshing the telematics – `updatedAt`
freezes. The integration then only logs the generic
`DEBUG "API did not return updated vehicle data"` every cycle, so it looks like
a fault.

The existing `privacy` binary sensor does not help: its `on_value` is `"None"`,
but `get_value` lower-cases the API value first, so it can never match `"null"`
(normal) or `"full"` (private). The entity is therefore permanently `off`.

## Change

- `const.py` `BINARY_SENSORS_DEFAULT["privacy"]`:
  - `on_value` `"None"` → `"Full"` (ON = private mode active);
  - drop the incorrect `device_class` (`LOCK`);
  - `icon` `mdi:alarm-light` (copy/paste from `alarm`) → `mdi:eye-off`;
  - `entity_category` = `DIAGNOSTIC`.
- `binary_sensor.py`: pass `entity_category` from the sensor definition into the
  `BinarySensorEntityDescription` (previously ignored).
- `base.py`: `_log_privacy_mode()` logs once at `INFO` when private mode starts
  pausing live data and once when it resumes.

## Behaviour

| | Before | After |
|---|---|---|
| `binary_sensor.<vin>_privacy` | always `off` | `on` while the car is in private mode |
| Private mode in the log | generic `DEBUG` line every cycle | one `INFO` on enter, one on leave |
