### PR TITLE
Improvement: Add position attributes to device_tracker entity

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -534,30 +534,55 @@ class StellantisBaseDevice(StellantisBaseEntity, TrackerEntity):
         return False
 
     @property
+    def _last_position(self):
+        """ Last known position feature. """
+        last_position = self._coordinator._data.get("lastPosition")
+        return last_position if isinstance(last_position, dict) else {}
+
+    @property
+    def _coordinates(self):
+        """ GPS coordinates [lon, lat, alt] of the last known position. """
+        geometry = self._last_position.get("geometry") or {}
+        coordinates = geometry.get("coordinates")
+        return coordinates if isinstance(coordinates, list) else []
+
+    @property
+    def _position_properties(self):
+        """ Properties of the last known position. """
+        properties = self._last_position.get("properties")
+        return properties if isinstance(properties, dict) else {}
+
+    @property
     def latitude(self):
         """ Latitude. """
-        if "lastPosition" in self._coordinator._data:
-            return float(self._coordinator._data["lastPosition"]["geometry"]["coordinates"][1])
-        return None
+        return float(self._coordinates[1]) if len(self._coordinates) >= 2 else None
 
     @property
     def longitude(self):
         """ Longitude. """
-        if "lastPosition" in self._coordinator._data:
-            return float(self._coordinator._data["lastPosition"]["geometry"]["coordinates"][0])
-        return None
+        return float(self._coordinates[0]) if len(self._coordinates) >= 2 else None
 
     @property
     def location_accuracy(self):
         """ Location accuracy. """
-        if "lastPosition" in self._coordinator._data:
-            return 10
-        return None
+        return 10 if len(self._coordinates) >= 2 else None
 
     @property
     def source_type(self):
         """ Source type. """
         return SourceType.GPS
+
+    @property
+    def extra_state_attributes(self):
+        """ Extra state attributes. """
+        attributes = dict(self._attr_extra_state_attributes)
+        coordinates = self._coordinates
+        properties = self._position_properties
+        attributes["altitude"] = float(coordinates[2]) if len(coordinates) == 3 else None
+        attributes["fix_status"] = properties.get("fixStatus")
+        attributes["signal_quality"] = properties.get("signalQuality")
+        attributes["position_updated_at"] = properties.get("createdAt")
+        return attributes
 
     def coordinator_update(self):
         """ Coordinator update. """

--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -339,7 +339,24 @@
     },
     "device_tracker": {
       "vehicle": {
-        "name": "Fahrzeug"
+        "name": "Fahrzeug",
+        "state_attributes": {
+          "altitude": {
+            "name": "Höhe"
+          },
+          "fix_status": {
+            "name": "Fix-Status"
+          },
+          "signal_quality": {
+            "name": "Signalqualität"
+          },
+          "position_updated_at": {
+            "name": "Aktualisiert am"
+          },
+          "entity_picture": {
+            "name": "Entitätsbild"
+          }
+        }
       }
     },
     "number": {

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -340,7 +340,24 @@
     },
     "device_tracker": {
       "vehicle": {
-        "name": "Vehicle"
+        "name": "Vehicle",
+        "state_attributes": {
+          "altitude": {
+            "name": "Altitude"
+          },
+          "fix_status": {
+            "name": "Fix status"
+          },
+          "signal_quality": {
+            "name": "Signal quality"
+          },
+          "position_updated_at": {
+            "name": "Updated at"
+          },
+          "entity_picture": {
+            "name": "Entity picture"
+          }
+        }
       }
     },
     "number": {

--- a/custom_components/stellantis_vehicles/translations/fr.json
+++ b/custom_components/stellantis_vehicles/translations/fr.json
@@ -340,7 +340,24 @@
     },
     "device_tracker": {
       "vehicle": {
-        "name": "Véhicule"
+        "name": "Véhicule",
+        "state_attributes": {
+          "altitude": {
+            "name": "Altitude"
+          },
+          "fix_status": {
+            "name": "État du fix"
+          },
+          "signal_quality": {
+            "name": "Qualité du signal"
+          },
+          "position_updated_at": {
+            "name": "Mis à jour à"
+          },
+          "entity_picture": {
+            "name": "Image de l'entité"
+          }
+        }
       }
     },
     "number": {

--- a/custom_components/stellantis_vehicles/translations/it.json
+++ b/custom_components/stellantis_vehicles/translations/it.json
@@ -336,7 +336,24 @@
     },
     "device_tracker": {
       "vehicle": {
-        "name": "Veicolo"
+        "name": "Veicolo",
+        "state_attributes": {
+          "altitude": {
+            "name": "Altitudine"
+          },
+          "fix_status": {
+            "name": "Stato del fix"
+          },
+          "signal_quality": {
+            "name": "Qualità del segnale"
+          },
+          "position_updated_at": {
+            "name": "Aggiornato il"
+          },
+          "entity_picture": {
+            "name": "Immagine entità"
+          }
+        }
       }
     },
     "number": {


### PR DESCRIPTION
Adds `extra_state_attributes` to the vehicle device tracker, exposing `altitude`, `fix_status`, `signal_quality` and `position_updated_at` from the last known position. Refactors the `lastPosition` lookups into safe `_last_position` / `_coordinates` / `_position_properties` helper properties so `latitude`, `longitude` and `location_accuracy` no longer raise on missing or malformed data