### PR TITLE
Run coordinator first refresh before forwarding platforms

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -44,19 +44,26 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
 
     if vehicles:
         stellantis.prune_stored_vehicle_configs({vehicle["vin"] for vehicle in vehicles})
+
+        # Build every coordinator and run its first refresh BEFORE forwarding the
+        # platforms - the standard Home Assistant setup order. A failing first
+        # refresh then raises ConfigEntryNotReady / ConfigEntryAuthFailed while no
+        # platform or entity is set up yet, so Home Assistant retries the whole
+        # entry cleanly. Entities are also created already holding the data from
+        # the first poll, instead of briefly existing with an empty coordinator.
+        for index, vehicle in enumerate(vehicles):
+            coordinator = await stellantis.async_get_coordinator(vehicle)
+            await coordinator.async_config_entry_first_refresh()
+            if index and len(vehicles) > 1:
+                # Spread the periodic polls of multiple vehicles across the
+                # interval instead of hitting the API for all of them at once.
+                coordinator.stagger_first_poll(index * UPDATE_INTERVAL / len(vehicles))
+
         await hass.config_entries.async_forward_entry_setups(config, PLATFORMS)
     else:
         _LOGGER.warning("No vehicles found for this account")
         await stellantis.hass_notify("no_vehicles_found")
         await stellantis.close_session()
-
-    for index, vehicle in enumerate(vehicles):
-        coordinator = await stellantis.async_get_coordinator(vehicle)
-        await coordinator.async_config_entry_first_refresh()
-        if index and len(vehicles) > 1:
-            # Spread the periodic polls of multiple vehicles across the interval
-            # instead of hitting the API for all of them at the same instant.
-            coordinator.stagger_first_poll(index * UPDATE_INTERVAL / len(vehicles))
 
     url = f"/stellantis_vehicles/{INTEGRATION_VERSION}/stellantis-vehicle-card.js"
     if url not in hass.data["frontend_extra_module_url"].urls:

--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -51,13 +51,24 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
         # platform or entity is set up yet, so Home Assistant retries the whole
         # entry cleanly. Entities are also created already holding the data from
         # the first poll, instead of briefly existing with an empty coordinator.
-        for index, vehicle in enumerate(vehicles):
-            coordinator = await stellantis.async_get_coordinator(vehicle)
-            await coordinator.async_config_entry_first_refresh()
-            if index and len(vehicles) > 1:
-                # Spread the periodic polls of multiple vehicles across the
-                # interval instead of hitting the API for all of them at once.
-                coordinator.stagger_first_poll(index * UPDATE_INTERVAL / len(vehicles))
+        try:
+            for index, vehicle in enumerate(vehicles):
+                coordinator = await stellantis.async_get_coordinator(vehicle)
+                await coordinator.async_config_entry_first_refresh()
+                if index and len(vehicles) > 1:
+                    # Spread the periodic polls of multiple vehicles across the
+                    # interval instead of hitting the API for all of them at once.
+                    coordinator.stagger_first_poll(index * UPDATE_INTERVAL / len(vehicles))
+        except Exception:
+            # First refresh failed (ConfigEntryNotReady / ConfigEntryAuthFailed /
+            # ...). Home Assistant does not call async_unload_entry when
+            # async_setup_entry raises, so drop this attempt's state here: the
+            # retry then starts from a clean slate and the scheduled
+            # token-refresh jobs from this attempt do not leak.
+            stellantis.reset_scheduled_tokens()
+            await stellantis.close_session()
+            hass.data[DOMAIN].pop(config.entry_id, None)
+            raise
 
         await hass.config_entries.async_forward_entry_setups(config, PLATFORMS)
     else:


### PR DESCRIPTION
### What
Reorder `async_setup_entry` so the per-vehicle coordinators are created and their first refresh runs **before** `async_forward_entry_setups()` — the standard Home Assistant setup order.

### Why
Today the platforms are forwarded first, then `async_config_entry_first_refresh()` runs. As a result:

- A failing first poll leaves the entry half-configured instead of raising a clean
  `ConfigEntryNotReady` / `ConfigEntryAuthFailed` before any platform is set up.
- Entities are added and then updated a moment later, so they flicker through
  empty/`unknown` values on every startup.
- With multiple vehicles, vehicle VIN_1's entities are left behind when vehicle VIN_2 fails.

Moving the refresh ahead of the forward fixes all three. `async_get_coordinator()` is idempotent and `get_user_vehicles()` is cached, so the platform files need no changes.

### Also included
Home Assistant does not call `async_unload_entry` when `async_setup_entry` raises, so the first-refresh loop now drops the failed attempt's state (`reset_scheduled_tokens()`, `close_session()`, `hass.data[DOMAIN].pop(entry_id)`) before re-raising, preventing leaked token-refresh jobs across retries.

### Testing
Manually verified against my running instance:

- Normal reload: entities appear immediately with values, no `unavailable` flicker.

### Scope
Only `custom_components/stellantis_vehicles/__init__.py` (`async_setup_entry`). No success-path behavior change beyond entity data being present one step earlier.
