### PR TITLE
Fully tear down MQTT, tasks and session on unload

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -71,11 +71,7 @@ async def async_unload_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     stellantis = hass.data[DOMAIN][config.entry_id]
 
     if unload_ok := await hass.config_entries.async_unload_platforms(config, PLATFORMS):
-        if stellantis.remote_commands and stellantis._mqtt:
-            stellantis._mqtt.disconnect()
-
-        stellantis.reset_scheduled_tokens()
-
+        await stellantis.async_shutdown()
         hass.data[DOMAIN].pop(config.entry_id)
 
     return unload_ok

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -121,6 +121,8 @@ class StellantisBase:
         self._config = {}
         self._session = None
         self.otp = None
+        self._shutting_down = False
+        self._pending_tasks: set[asyncio.Task] = set()
 
         self.logger_filter = SensitiveDataFilter()
         _LOGGER.addFilter(self.logger_filter)
@@ -273,10 +275,29 @@ class StellantisBase:
             raise
 
     def do_async(self, async_func, delay=0, wait=True):
+        if self._shutting_down:
+            # The config entry is being unloaded - drop the coroutine instead of
+            # scheduling work that would resurrect the MQTT client or hit an
+            # already closed aiohttp session.
+            async_func.close()
+            return None
+
         async def delayed_execution():
-            if delay > 0:
-                await asyncio.sleep(delay)
-            return await async_func
+            task = asyncio.current_task()
+            self._pending_tasks.add(task)
+            try:
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                if self._shutting_down:
+                    async_func.close()
+                    return None
+                return await async_func
+            except asyncio.CancelledError:
+                async_func.close()
+                raise
+            finally:
+                self._pending_tasks.discard(task)
+
         future = asyncio.run_coroutine_threadsafe(delayed_execution(), self._hass.loop)
         return future.result() if wait else None
 
@@ -541,6 +562,39 @@ class StellantisVehicles(StellantisOauth):
             self._mqtt_token_scheduled()
             self._mqtt_token_scheduled = None
 
+    # TODO: once bugfix/first-refresh-before-platforms is merged, route its
+    # setup-failure cleanup block through async_shutdown() instead of calling
+    # reset_scheduled_tokens() + close_session() separately.
+    async def async_shutdown(self) -> None:
+        """Tear down everything created for this config entry.
+
+        Called from async_unload_entry so a reload does not leak the paho-mqtt
+        network thread, the delayed do_async reconnect tasks, the scheduled
+        token-refresh callbacks or the aiohttp session.
+        """
+        self._shutting_down = True
+
+        # Stop the scheduled oauth/mqtt token-refresh callbacks.
+        self.reset_scheduled_tokens()
+
+        # Cancel any pending (possibly still sleeping) do_async coroutines,
+        # e.g. the 300s MQTT reconnect scheduled from _on_mqtt_subscribe.
+        for task in list(self._pending_tasks):
+            task.cancel()
+        self._pending_tasks.clear()
+
+        # Tear down the MQTT client and join its network thread.
+        if self._mqtt is not None:
+            mqtt_client, self._mqtt = self._mqtt, None
+            # Drop the reconnect / token-refresh callback so the deliberate
+            # disconnect below does not trigger a fresh reconnect attempt.
+            mqtt_client.on_disconnect = None
+            mqtt_client.disconnect()
+            await self._hass.async_add_executor_job(mqtt_client.loop_stop)
+
+        # Close the shared aiohttp session.
+        await self.close_session()
+
     async def scheduled_tokens_refresh(self):
         self.reset_scheduled_tokens()
         await self.scheduled_oauth_token_refresh()
@@ -755,6 +809,11 @@ class StellantisVehicles(StellantisOauth):
 
     async def connect_mqtt(self):
         _LOGGER.debug("---------- START connect_mqtt")
+        if self._shutting_down:
+            # A coordinator refresh still in flight during unload must not
+            # recreate the MQTT client async_shutdown just tore down.
+            _LOGGER.debug("---------- END connect_mqtt")
+            return False
         if self._mqtt is None:
             self._mqtt = MqttClientMod(clean_session=True, protocol=mqtt.MQTTv311)
             # self._mqtt.enable_logger(logger=_LOGGER)


### PR DESCRIPTION
## As of today

`async_unload_entry` only calls `_mqtt.disconnect()`. It never calls `loop_stop()`, never clears `self._mqtt`, and never cancels the delayed `do_async` coroutines or closes the aiohttp session. As a result, **every reload of the integration leaks**:

- **The paho-mqtt network thread** started by `loop_start()`. `disconnect()` alone only stops it reliably when the client is cleanly connected; if it is mid-reconnect (e.g. after a failed `connect()` in `connect_mqtt`, where `loop_start()` is still called) the thread keeps retrying.
- **The 300 s reconnect** scheduled from `_on_mqtt_subscribe` via `do_async(self.connect_mqtt(), 300, wait=False)`, and the token refresh scheduled from `_on_mqtt_disconnect`. These `run_coroutine_threadsafe` futures are never tracked, so a sleeping one fires *after* the unload and recreates the MQTT client on the now-orphaned instance.
- **The shared `aiohttp.ClientSession`** — only closed on the no-vehicles / setup-failure paths, not on a normal unload.

Because the paho thread and the pending coroutines hold bound-method references to the old `StellantisVehicles` instance, the whole object graph stays alive too. Repeated reloads pile up threads and tasks.

There is also a smaller issue: the teardown is guarded by `if stellantis.remote_commands and stellantis._mqtt`. If remote commands were switched off at runtime (`disable_remote_commands()`) while an MQTT connection is still up, the thread is never stopped.

## Changes

- **New `StellantisVehicles.async_shutdown()`**, called from `async_unload_entry`:
  - sets a `_shutting_down` flag;
  - `reset_scheduled_tokens()` (unchanged behaviour);
  - cancels every pending `do_async` task (including a still-sleeping 300 s reconnect);
  - detaches `on_disconnect`, calls `disconnect()` **and** `loop_stop()` (in the executor, since it joins the network thread), then sets `_mqtt = None`;
  - `close_session()`.
- **`do_async`** now:
  - short-circuits (and closes the coroutine) when `_shutting_down` is set, so MQTT callbacks firing during teardown cannot schedule new work;
  - registers its task in `_pending_tasks` (mutated only on the event loop, so no locking) and cleans up in `finally`.
- **`connect_mqtt()`** bails out early when `_shutting_down` is set, so a coordinator refresh still in flight during unload cannot recreate the client.
- **`async_unload_entry`** drops the `remote_commands` condition — `async_shutdown` handles `_mqtt is None` itself.

## Impact

- After an unload/reload only one paho network thread exists (the new entry's), not one per reload.
- No orphaned reconnect coroutines, no `Unclosed client session` warning.
- The old `StellantisVehicles` instance becomes collectable immediately.
- The deliberate `disconnect()` during unload no longer triggers a token refresh / reconnect (callback detached).
- `loop_stop()` runs in the executor and joins the network thread (worst case ~1 s); it does not block the event loop.

## Testing

Validated manually against my running Home Assistant instance:

- reload the integration several times with remote commands enabled → one MQTT connect per reload, thread count stable, no `coroutine ... was never awaited` and no `Unclosed client session` warnings;
- switch remote commands off, then reload → MQTT thread is still stopped (previously skipped by the `remote_commands` guard);
- send a remote command after a reload → MQTT round-trip still works;
- remove the config entry entirely → `async_remove_entry` cleanup unchanged.