### PR TITLE
Guard get_user_info against an empty API response

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -338,12 +338,10 @@ class StellantisOauth(StellantisBase):
         headers = self.apply_dict_params(GET_OTP_HEADERS)
         headers["x-transaction-id"] = "1234"
         user_request = await self.make_http_request(url, 'GET', headers)
-        if "customer" in user_request[0]:
-            self.logger_filter.add_custom_value(user_request[0]["customer"])
-        if "vehicle" in user_request[0]:
-            self.logger_filter.add_custom_value(user_request[0]["vehicle"])
-        if "car_association_id" in user_request[0]:
-            self.logger_filter.add_custom_value(user_request[0]["car_association_id"])
+        user_info = user_request[0] if isinstance(user_request, list) and user_request else {}
+        for key in ("customer", "vehicle", "car_association_id"):
+            if key in user_info:
+                self.logger_filter.add_custom_value(user_info[key])
         _LOGGER.debug(url)
         _LOGGER.debug(headers)
         _LOGGER.debug(user_request)


### PR DESCRIPTION
### As of today

`get_user_info()` indexes `user_request[0]` directly. `make_http_request()` returns `{}` when the response body is empty (and on a handled `404 / 40400`), so `user_request[0]` raises `KeyError: 0` instead of letting the caller deal with the missing data.

The config-flow OTP step (`async_step_otp`) already guards for this:

```python
if not user_info_request or "customer" not in user_info_request[0]:
    message = self.get_error_message("missing_user_info")
    ...
```
but it never gets there — the KeyError is raised inside get_user_info() first and surfaces as a generic get_user_info error plus a traceback in the log.

### Change
Resolve the first list element defensively: `user_info = user_request[0] if isinstance(user_request, list) and user_request else {}` Fold the three repeated `if "…" in user_request[0]` blocks into a small loop. The return value is unchanged, so the existing caller guard now works as intended and the flow shows `missing_user_info` instead of crashing.

