### PR TITLE
Fix misspelled identifiers (ComunicationError, consuption)

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
 
 from .stellantis import StellantisVehicles
-from .exceptions import ComunicationError
+from .exceptions import CommunicationError
 from .config_flow import StellantisVehiclesConfigFlow
 
 from .const import (
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
 
     try:
         vehicles = await stellantis.get_user_vehicles()
-    except (ConfigEntryAuthFailed, ComunicationError):
+    except (ConfigEntryAuthFailed, CommunicationError):
         raise
     except Exception:
         vehicles = {}

--- a/custom_components/stellantis_vehicles/exceptions.py
+++ b/custom_components/stellantis_vehicles/exceptions.py
@@ -1,5 +1,5 @@
 class RateLimitException(Exception):
     pass
 
-class ComunicationError(Exception):
+class CommunicationError(Exception):
     pass

--- a/custom_components/stellantis_vehicles/sensor.py
+++ b/custom_components/stellantis_vehicles/sensor.py
@@ -136,10 +136,10 @@ class StellantisLastTripSensor(StellantisRestoreSensor):
                 max_speed_kmh = float(last_trip["kinetic"]["maxSpeed"])
                 attributes["max_speed"] = str(round(max_speed_kmh, 2)) + " " + UnitOfSpeed.KILOMETERS_PER_HOUR
         if "energyConsumptions" in last_trip:
-            for consuption in last_trip["energyConsumptions"]:
-                if "type" not in consuption:
+            for consumption in last_trip["energyConsumptions"]:
+                if "type" not in consumption:
                     continue
-                if consuption["type"] == VEHICLE_TYPE_ELECTRIC:
+                if consumption["type"] == VEHICLE_TYPE_ELECTRIC:
                     consumption_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
                     avg_consumption_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR+"/100"+UnitOfLength.KILOMETERS
                     divide = 1000
@@ -150,10 +150,10 @@ class StellantisLastTripSensor(StellantisRestoreSensor):
                     consumption_unit_of_measurement = UnitOfVolume.LITERS
                     avg_consumption_unit_of_measurement = UnitOfVolume.LITERS+"/100"+UnitOfLength.KILOMETERS
                     divide = 100
-                if "consumption" in consuption and round(float(consuption["consumption"])/divide, 2) > 0:
-                    attributes[consuption["type"].lower() + "_consumption"] = str(round(float(consuption["consumption"])/divide, 2)) + " " + consumption_unit_of_measurement
-                if "avgConsumption" in consuption and round(float(consuption["avgConsumption"])/divide, 2) > 0:
-                    attributes[consuption["type"].lower() + "_avg_consumption"] = str(round(float(consuption["avgConsumption"])/divide, 2)) + " " + avg_consumption_unit_of_measurement
+                if "consumption" in consumption and round(float(consumption["consumption"])/divide, 2) > 0:
+                    attributes[consumption["type"].lower() + "_consumption"] = str(round(float(consumption["consumption"])/divide, 2)) + " " + consumption_unit_of_measurement
+                if "avgConsumption" in consumption and round(float(consumption["avgConsumption"])/divide, 2) > 0:
+                    attributes[consumption["type"].lower() + "_avg_consumption"] = str(round(float(consumption["avgConsumption"])/divide, 2)) + " " + avg_consumption_unit_of_measurement
         self._attr_extra_state_attributes = attributes
 
 # class StellantisTotalTripSensor(StellantisRestoreSensor):

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.event import async_track_point_in_time
 from .base import StellantisVehicleCoordinator
 from .otp.otp import Otp, save_otp, load_otp, ConfigException
 from .utils import ( get_datetime, rate_limit, SensitiveDataFilter, replace_string_placeholders )
-from .exceptions import ( ComunicationError, RateLimitException )
+from .exceptions import ( CommunicationError, RateLimitException )
 
 from .const import (
     DOMAIN,
@@ -235,18 +235,18 @@ class StellantisBase:
                     if str(resp.status) == "500" and str(result.get("code")) == "50000":
                         # Connection module replaced (https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/388)
                         # https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/pull/475
-                        raise ComunicationError(error)
+                        raise CommunicationError(error)
                     if str(resp.status) == "400" and result.get("error") == "invalid_grant":
                         # Token expiration
                         raise ConfigEntryAuthFailed(error)
                     if str(resp.status) == "401":
                         # Oauth token seem expired, refresh request blocked by server/connection error
-                        raise ComunicationError(error)
+                        raise CommunicationError(error)
                     if str(resp.status).startswith("50"):
                         # Internal error
-                        raise ComunicationError(error)
+                        raise CommunicationError(error)
                     # Any other non-2xx response we don't have a specific case for
-                    raise ComunicationError(error or f"Unexpected HTTP status {resp.status}")
+                    raise CommunicationError(error or f"Unexpected HTTP status {resp.status}")
 
                 _LOGGER.debug("---------- END make_http_request")
                 return result
@@ -255,14 +255,14 @@ class StellantisBase:
             _LOGGER.warning(f"Error: {e}")
             _LOGGER.debug("---------- END make_http_request")
             # Connection error
-            raise ComunicationError("Request timeout") from e
+            raise CommunicationError("Request timeout") from e
         except aiohttp.client_exceptions.ClientError as e:
             await self.close_session()
             _LOGGER.warning(f"Error: {e}")
             _LOGGER.debug("---------- END make_http_request")
             # Connection error
-            raise ComunicationError(e) from e
-        except (ConfigEntryAuthFailed, ComunicationError):
+            raise CommunicationError(e) from e
+        except (ConfigEntryAuthFailed, CommunicationError):
             await self.close_session()
             _LOGGER.debug("---------- END make_http_request")
             raise
@@ -558,7 +558,7 @@ class StellantisVehicles(StellantisOauth):
             elif get_datetime() > get_next_run():
                 await self.refresh_token_request()
             next_run = get_next_run()
-        except ComunicationError:
+        except CommunicationError:
             next_run = get_datetime() + timedelta(minutes=5)
         except RateLimitException:
             _LOGGER.warning("Rate limit exceeded, retry after 30 mins or check logs and restart integration")
@@ -700,7 +700,7 @@ class StellantisVehicles(StellantisOauth):
             if force or get_datetime() > get_next_run():
                 await self.refresh_mqtt_token_request()
             next_run = get_next_run()
-        except ComunicationError:
+        except CommunicationError:
             next_run = get_datetime() + timedelta(minutes=1)
         except RateLimitException:
             _LOGGER.warning("Rate limit exceeded, retry after 1 day or check logs and restart integration")


### PR DESCRIPTION
Pure rename, no behavior change.

### `ComunicationError` → `CommunicationError`

The custom exception class in `exceptions.py` and every reference in `stellantis.py` (import + raise/except sites) and `__init__.py` (import + except). 13 occurrences. Internal only — the name is not part of any API payload or translation key.

### `consuption` → `consumption`

The loop variable in `StellantisLastTripSensor.coordinator_update` (`sensor.py`). The API keys it reads (`type`, `consumption`, `avgConsumption`) and the extra-state-attribute names it writes (`*_consumption`, `*_avg_consumption`) are **unchanged**.

### Left as-is on purpose

* A commented-out legacy trip block in `base.py` that still contains `consuption` (dead code).

### Testing

Manual: integration loads, last-trip sensor attributes are identical, and the `CommunicationError` raise/except paths in `make_http_request` and the token refresh loops still behave as before.