### PR TITLE
Reuse async_shutdown for the setup-failure cleanup path

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -63,10 +63,10 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
             # First refresh failed (ConfigEntryNotReady / ConfigEntryAuthFailed /
             # ...). Home Assistant does not call async_unload_entry when
             # async_setup_entry raises, so drop this attempt's state here: the
-            # retry then starts from a clean slate and the scheduled
-            # token-refresh jobs from this attempt do not leak.
-            stellantis.reset_scheduled_tokens()
-            await stellantis.close_session()
+            # retry then starts from a clean slate and the MQTT client, pending
+            # tasks, scheduled token-refresh jobs and aiohttp session from this
+            # attempt do not leak.
+            await stellantis.async_shutdown()
             hass.data[DOMAIN].pop(config.entry_id, None)
             raise
 

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -560,9 +560,6 @@ class StellantisVehicles(StellantisOauth):
             self._mqtt_token_scheduled()
             self._mqtt_token_scheduled = None
 
-    # TODO: once bugfix/first-refresh-before-platforms is merged, route its
-    # setup-failure cleanup block through async_shutdown() instead of calling
-    # reset_scheduled_tokens() + close_session() separately.
     async def async_shutdown(self) -> None:
         """Tear down everything created for this config entry.
 


### PR DESCRIPTION
## What

When the first coordinator refresh fails, `async_setup_entry` now calls
`stellantis.async_shutdown()` instead of running `reset_scheduled_tokens()`
and `close_session()` on their own.

## Why

Home Assistant does not call `async_unload_entry` when `async_setup_entry`
raises, so the failed attempt has to clean up after itself. `async_shutdown()`
is the single place that already does the full teardown (MQTT client, pending
reconnect tasks, scheduled token-refresh jobs, aiohttp session), so the
setup-failure path now matches the unload path and can no longer leak the
MQTT thread or pending tasks.

## Notes

- Also removes the stale `TODO` above `async_shutdown()` that tracked this.
- No functional change on success; only the failure path is affected.
