### PR TITLE
Trigger reauth via the coordinator's own config entry

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -225,7 +225,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                 self.async_update_listeners()
         except ConfigEntryAuthFailed as e:
             _LOGGER.warning("Authentication failed while sending command '%s' to vehicle '%s': %s", name, self._vehicle['vin'], str(e))
-            self._stellantis._entry.async_start_reauth(self._hass)
+            self.config_entry.async_start_reauth(self.hass)
         except Exception as e:
             _LOGGER.error("Failed to send command %s: %s", name, str(e))
             raise


### PR DESCRIPTION
### What

When a vehicle command fails with `ConfigEntryAuthFailed`, `send_command` now starts the reauth flow through the coordinator's own `self.config_entry` instead of reaching into the client's private `self._stellantis._entry`.

### Why

`DataUpdateCoordinator` already receives and stores the config entry (`config_entry=` is passed when the coordinator is built), so it can start reauth itself. Going through `_stellantis._entry` couples the coordinator to a private attribute of the client and only works because the client happens to hold the same entry.

### Behavior

No functional change. `set_entry()` runs before any coordinator is created, so `self.config_entry` is the exact same `ConfigEntry` object that was used before; `self.hass` is the standard base-class attribute. `async_start_reauth` de-duplicates in-flight reauth flows either way.

