### PR TITLE
Keep last vehicle data on an empty status response

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -84,13 +84,30 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             raise UpdateFailed("Error communicating with Stellantis API") from err
 
         if not new_data:
+            # Keep the last known data instead of blanking every entity on a
+            # single empty response (404 / empty body).
             self._empty_status_count += 1
-            if self._empty_status_count >= EMPTY_STATUS_LIMIT and not self._vehicle_removed:
+            _LOGGER.debug(
+                "Empty vehicle status response (%s in a row), keeping last known data",
+                self._empty_status_count,
+            )
+
+            if self._empty_status_count < EMPTY_STATUS_LIMIT:
+                # Short gap: keep the last known data.
+                _LOGGER.debug("---------- END _async_update_data")
+                return
+
+            if self._empty_status_count % EMPTY_STATUS_LIMIT == 0 and not self._vehicle_removed:
+                # Periodically check whether the vehicle was unpaired.
                 await self._reconcile_vehicle()
-        else:
-            self._empty_status_count = 0
-            self._clear_vehicle_removed()
-            self._log_privacy_mode(new_data.get("privacy", {}).get("state"))
+
+            # Sustained outage: surface it so entities go unavailable.
+            _LOGGER.debug("---------- END _async_update_data")
+            raise UpdateFailed("Empty vehicle status response")
+
+        self._empty_status_count = 0
+        self._clear_vehicle_removed()
+        self._log_privacy_mode(new_data.get("privacy", {}).get("state"))
 
         if "updatedAt" in new_data and "updatedAt" in self._data:
             try:
@@ -132,7 +149,11 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             _LOGGER.info("Private mode is disabled on vehicle %s, live data updates resumed", self._vehicle["vin"])
 
     async def _reconcile_vehicle(self):
-        """ Re-fetch the account vehicle list to check whether this vehicle was unpaired. """
+        """ Re-fetch the account vehicle list to check whether this vehicle was unpaired.
+
+        Sets ``self._vehicle_removed`` and raises a repair issue only when the
+        vehicle is confirmed gone from the account.
+        """
         vin = self._vehicle["vin"]
         try:
             live = await self._stellantis.get_user_vehicles(force=True)
@@ -142,7 +163,6 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         live_vins = {vehicle.get("vin") for vehicle in live}
         if not live_vins or vin in live_vins:
             # List unavailable or the vehicle is still there: keep polling.
-            self._empty_status_count = 0
             return
         self._vehicle_removed = True
         _LOGGER.warning("Vehicle %s is no longer linked to this Stellantis account", vin)


### PR DESCRIPTION
### Problem

When `get_vehicle_status()` returns an empty payload (`{}` from a 404 / empty body), `_async_update_data` still ran `self._data = new_data`, wiping every entity to `unknown` / `unavailable` on a **single** empty poll. `_reconcile_vehicle()` only intervenes after `EMPTY_STATUS_LIMIT` consecutive empty polls, so a short transient gap blanked the whole vehicle view for up to that window.

### Change

In the `if not new_data:` branch:

- **Never overwrite `self._data` with an empty response.** The last known values are kept.
- **Tolerate short gaps:** below `EMPTY_STATUS_LIMIT` consecutive empty polls the coordinator just returns, so a one-off blip passes unnoticed and recovers instantly on the next good poll.
- **Surface a sustained outage:** once `EMPTY_STATUS_LIMIT` is reached the coordinator raises `UpdateFailed`, so entities go `unavailable` instead of showing wiped state.
- The periodic unpaired-vehicle check (`_reconcile_vehicle()`) still runs, now throttled to every `EMPTY_STATUS_LIMIT`-th poll and skipped once the vehicle is confirmed gone (avoids re-hitting the vehicle-list endpoint and re-logging the warning every minute).

`_reconcile_vehicle()` no longer resets `_empty_status_count` — the counter is now reset only on a successful non-empty poll. Its remaining job is unchanged: flag a confirmed-removed vehicle and raise the repair issue.

### Behavior

| Situation | Result |
| --- | --- |
| 1–2 empty polls, then data | Last values kept throughout, no failure |
| ≥ `EMPTY_STATUS_LIMIT` empty polls, vehicle still linked | `UpdateFailed` each poll → entities unavailable |
| ≥ `EMPTY_STATUS_LIMIT` empty polls, vehicle unpaired | `_vehicle_removed` set, repair issue raised once, no repeated warning |
| Vehicle answers again | Counter reset, repair issue cleared, recovery logged once |
| Reload / restart during an outage | Setup still completes with restored values; entities go unavailable once the limit is hit |
