### PR TITLE
Add frontend to manifest dependencies

### DIFF
--- a/custom_components/stellantis_vehicles/manifest.json
+++ b/custom_components/stellantis_vehicles/manifest.json
@@ -6,8 +6,9 @@
   ],
   "config_flow": true,
   "dependencies": [
-    "webhook",
-    "http"
+    "frontend",
+    "http",
+    "webhook"
   ],
   "documentation": "https://github.com/andreadegiovine/homeassistant-stellantis-vehicles",
   "iot_class": "cloud_polling",


### PR DESCRIPTION
## Summary

`async_setup_entry` registers the Lovelace card at the end of setup by reading
`hass.data["frontend_extra_module_url"]` and calling `add_extra_js_url` from
`homeassistant.components.frontend`:

```python
url = f"/stellantis_vehicles/{INTEGRATION_VERSION}/stellantis-vehicle-card.js"
if url not in hass.data["frontend_extra_module_url"].urls:
    ...
    add_extra_js_url(hass, url)
```

That `hass.data` key only exists once the `frontend` integration has finished
its own setup. `frontend` was not listed in `manifest.json`, so setup only
worked because `frontend` happened to be loaded already (via `default_config`).

On a configuration without `frontend`, or when `frontend` is set up after this
integration, `async_setup_entry` raises `KeyError: 'frontend_extra_module_url'`
and the config entry fails to load.

## Change

Add `frontend` to `dependencies` so Home Assistant guarantees it is set up
first (and pulls it in if it is not configured). The `dependencies` list is
also sorted alphabetically.

```diff
   "dependencies": [
-    "webhook",
-    "http"
+    "frontend",
+    "http",
+    "webhook"
   ],
```

## Test plan

- [x] Reload the integration on an instance with `default_config` — card still registers, no behavior change.
- [x] Setup no longer depends on load order for the `frontend_extra_module_url` lookup.
