### PR TITLE
Set PARALLEL_UPDATES on all entity platforms

### DIFF
--- a/custom_components/stellantis_vehicles/binary_sensor.py
+++ b/custom_components/stellantis_vehicles/binary_sensor.py
@@ -13,6 +13,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Read-only platform, all state is provided by the coordinator.
+PARALLEL_UPDATES = 0
+
 async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> None:
     stellantis = hass.data[DOMAIN][entry.entry_id]
     entities = []

--- a/custom_components/stellantis_vehicles/button.py
+++ b/custom_components/stellantis_vehicles/button.py
@@ -14,6 +14,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Serialize command calls so a bulk action can't flood the Stellantis cloud.
+PARALLEL_UPDATES = 1
+
 async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> None:
     stellantis = hass.data[DOMAIN][entry.entry_id]
 

--- a/custom_components/stellantis_vehicles/device_tracker.py
+++ b/custom_components/stellantis_vehicles/device_tracker.py
@@ -12,6 +12,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Read-only platform, all state is provided by the coordinator.
+PARALLEL_UPDATES = 0
+
 async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> None:
     stellantis = hass.data[DOMAIN][entry.entry_id]
     entities = []

--- a/custom_components/stellantis_vehicles/number.py
+++ b/custom_components/stellantis_vehicles/number.py
@@ -16,6 +16,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Serialize command calls so a bulk action can't flood the Stellantis cloud.
+PARALLEL_UPDATES = 1
+
 async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> None:
     stellantis = hass.data[DOMAIN][entry.entry_id]
     entities = []

--- a/custom_components/stellantis_vehicles/sensor.py
+++ b/custom_components/stellantis_vehicles/sensor.py
@@ -22,6 +22,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Read-only platform, all state is provided by the coordinator.
+PARALLEL_UPDATES = 0
+
 async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> None:
     stellantis = hass.data[DOMAIN][entry.entry_id]
     entities = []

--- a/custom_components/stellantis_vehicles/switch.py
+++ b/custom_components/stellantis_vehicles/switch.py
@@ -14,6 +14,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Serialize command calls so a bulk action can't flood the Stellantis cloud.
+PARALLEL_UPDATES = 1
+
 async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> None:
     stellantis = hass.data[DOMAIN][entry.entry_id]
     entities = []

--- a/custom_components/stellantis_vehicles/text.py
+++ b/custom_components/stellantis_vehicles/text.py
@@ -14,6 +14,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Serialize command calls so a bulk action can't flood the Stellantis cloud.
+PARALLEL_UPDATES = 1
+
 async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> None:
     stellantis = hass.data[DOMAIN][entry.entry_id]
     entities = []

--- a/custom_components/stellantis_vehicles/time.py
+++ b/custom_components/stellantis_vehicles/time.py
@@ -13,6 +13,9 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Serialize command calls so a bulk action can't flood the Stellantis cloud.
+PARALLEL_UPDATES = 1
+
 async def async_setup_entry(hass:HomeAssistant, entry, async_add_entities) -> None:
     stellantis = hass.data[DOMAIN][entry.entry_id]
     entities = []


### PR DESCRIPTION
## Summary

Declare `PARALLEL_UPDATES` in every entity platform module. Until now none of the platforms set it, so Home Assistant applied its implicit default to all of them.

- **Read-only platforms** – `sensor`, `binary_sensor`, `device_tracker` – set `PARALLEL_UPDATES = 0`. All state comes from the coordinator, so there is nothing to throttle. This is a no-op at runtime and just makes the intent explicit.
- **Command platforms** – `button`, `switch`, `number`, `text`, `time` – set `PARALLEL_UPDATES = 1`. Their entity service calls end up in `send_command()` → `send_mqtt_message()` against the Stellantis cloud, and only `send_wakeup_command` is rate limited. With no semaphore, a bulk action (a scene, a script, an entity group, or acting on several vehicles at once) fires all of those requests concurrently, which risks cloud-side rate limiting and command races. A value of `1` serializes them per platform per config entry.

See https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/parallel-updates/

## Impact

- Single command from the UI: unchanged.
- Bulk actions: the commands are now sent one after another instead of all at
  once. Slightly slower to complete, but they all get through and in order.
- Sensor / diagnostic entities: no behavior change.

## Testing

Verified manually against my running Home Assistant instance: integration reloads cleanly, entity states unchanged, and triggering multiple command entities together sends the requests sequentially instead of in parallel.
