### PR TITLE
Harden error handling in the setup, MQTT and OTP paths

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -4,13 +4,12 @@ import os
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import issue_registry, device_registry as dr
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
 
 from .stellantis import StellantisVehicles
-from .exceptions import CommunicationError
 from .config_flow import StellantisVehiclesConfigFlow
 
 from .const import (
@@ -37,10 +36,17 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry):
 
     try:
         vehicles = await stellantis.get_user_vehicles()
-    except (ConfigEntryAuthFailed, CommunicationError):
+    except ConfigEntryAuthFailed:
         raise
-    except Exception:
-        vehicles = {}
+    except Exception as err:
+        # Home Assistant does not call async_unload_entry when async_setup_entry
+        # raises, so drop this attempt's state (pending tasks, scheduled
+        # token-refresh jobs, aiohttp session) before bubbling up. Raising
+        # ConfigEntryNotReady makes Home Assistant retry with backoff instead of
+        # leaving a loaded but empty entry behind a misleading "no vehicles" notice.
+        await stellantis.async_shutdown()
+        hass.data[DOMAIN].pop(config.entry_id, None)
+        raise ConfigEntryNotReady(f"Could not fetch the vehicle list: {err}") from err
 
     if vehicles:
         stellantis.prune_stored_vehicle_configs({vehicle["vin"] for vehicle in vehicles})

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -392,8 +392,8 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             if "_embedded" in trips and "trips" in trips["_embedded"] and trips["_embedded"]["trips"]:
                 if not self._last_trip or self._last_trip["id"] != trips["_embedded"]["trips"][-1]["id"]:
                     self._last_trip = trips["_embedded"]["trips"][-1]
-        except Exception:
-            pass
+        except Exception as e:
+            _LOGGER.warning("Failed to fetch last trip data: %s", e)
 
 #     def parse_trips_page_data(self, data):
 #         result = []

--- a/custom_components/stellantis_vehicles/otp/otp.py
+++ b/custom_components/stellantis_vehicles/otp/otp.py
@@ -171,9 +171,9 @@ class Otp:
             if setup:
                 return etree_to_dict(ElT.XML(raw_xml))["ActionSetup"]
             return etree_to_dict(ElT.XML(raw_xml))["ActionFinalize"]
-        except KeyError:
+        except KeyError as e:
             logger.debug(raw_xml)
-            raise ValueError("Bad response from server") from KeyError
+            raise ValueError("Bad response from server") from e
 
     def activation_start(self):
         param = {"action": "ActionSetup", "mode": self.mode, "id": self.data.iwid, "lastsync": self.data.iwTsync,
@@ -217,8 +217,8 @@ class Otp:
         if self.mode == Otp.OTP_MODE:
             try:
                 self.defi = str(xml["defi"])
-            except KeyError:
-                raise ConfigException from KeyError
+            except KeyError as e:
+                raise ConfigException("Missing 'defi' in OTP response") from e
             if "J" in xml:
                 logger.debug("Need another otp request")
                 return Otp.OTP_TWICE

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -651,6 +651,11 @@ class StellantisVehicles(StellantisOauth):
             url = self.apply_query_params(CAR_API_VEHICLES_URL, CLIENT_ID_QUERY_PARAMS)
             headers = self.apply_dict_params(CAR_API_HEADERS)
             vehicles_request = await self.make_http_request(url, 'GET', headers)
+            if not isinstance(vehicles_request, dict) or not vehicles_request:
+                # An empty or non-object body on a 2xx response is not a valid
+                # vehicle list. Treat it as a transient API problem instead of
+                # reporting the account as having no vehicles.
+                raise CommunicationError("Empty or invalid response from the vehicles endpoint")
             if "_embedded" in vehicles_request:
                 if "vehicles" in vehicles_request["_embedded"]:
                     for vehicle in vehicles_request["_embedded"]["vehicles"]:

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -377,10 +377,13 @@ class StellantisOauth(StellantisBase):
             if self.otp.activation_start():
                 finalyze = self.otp.activation_finalyze()
                 if finalyze != 0:
-                    raise Exception(finalyze)
+                    raise ConfigException(finalyze)
+        except ConfigException as e:
+            _LOGGER.error(str(e))
+            raise
         except Exception as e:
             _LOGGER.error(str(e))
-            raise Exception(str(e))
+            raise ConfigException(str(e)) from e
 
     async def get_otp_sms(self):
         _LOGGER.debug("---------- START get_otp_sms")

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -367,7 +367,10 @@ class StellantisOauth(StellantisBase):
         _LOGGER.debug(headers)
         _LOGGER.debug(user_request)
         _LOGGER.debug("---------- END get_user_info")
-        return user_request
+        # Always hand back a list so callers can safely index [0]; a non-list
+        # body (error object, changed shape) becomes an empty list, which the
+        # config flow reports as missing user info.
+        return user_request if isinstance(user_request, list) else []
 
     def new_otp(self, sms_code, pin_code):
         try:

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -848,11 +848,11 @@ class StellantisVehicles(StellantisOauth):
     def _on_mqtt_disconnect(self, client, userdata, result_code):
         _LOGGER.debug("---------- START _on_mqtt_disconnect")
         _LOGGER.debug(f"Code: {result_code} -> {mqtt.error_string(result_code)}")
-        try:
-            if result_code == 11: # MQTT_ERR_AUTH
-                self.do_async(self.scheduled_mqtt_token_refresh(force=True))
-        except Exception:
-            pass  # refresh_mqtt_token already logs the exception, and raising would halt the Paho reconnect loop
+        if result_code == 11: # MQTT_ERR_AUTH
+            # Runs on the paho network thread; wait=False keeps the reconnect loop
+            # from blocking on the token refresh (network I/O, no timeout).
+            # do_async already guards shutdown and the coroutine logs its own errors.
+            self.do_async(self.scheduled_mqtt_token_refresh(force=True), wait=False)
         _LOGGER.debug("---------- END _on_mqtt_disconnect")
 
     def _on_mqtt_subscribe(self, client, userdata, mid, granted_qos):
@@ -900,7 +900,10 @@ class StellantisVehicles(StellantisOauth):
                             _LOGGER.debug("The mqtt token seems invalid, refresh the token and try sending the request again")
                             last_request = self._mqtt_last_request
                             self._mqtt_last_request = None
-                            self.do_async(self.send_mqtt_message(last_request[0], last_request[1], coordinator._vehicle, False, data["correlation_id"]))
+                            # wait=False: don't block the paho network thread while the
+                            # retry forces a token refresh; the result comes back as a
+                            # fresh MQTT response and send_mqtt_message logs its own errors
+                            self.do_async(self.send_mqtt_message(last_request[0], last_request[1], coordinator._vehicle, False, data["correlation_id"]), wait=False)
                             _LOGGER.debug("---------- END _on_mqtt_message")
                             return
                         else:
@@ -908,13 +911,15 @@ class StellantisVehicles(StellantisOauth):
                             result_code = "failed"
                     if result_code == "113":  # Error: vin (https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/388)
                         result_code = "failed"
+                    # wait=False: fire-and-forget so the paho network thread isn't
+                    # blocked (the results aren't used here anyway)
                     if result_code in ["300", "500", "not_compatible", "failed"]:
-                        self.do_async(self.hass_notify("command_error"))
+                        self.do_async(self.hass_notify("command_error"), wait=False)
                     if result_code == "0":
                         _LOGGER.debug(f"Fetch updates after code: {result_code}")
-                        self.do_async(coordinator.async_refresh(), 10)
+                        self.do_async(coordinator.async_refresh(), 10, wait=False)
 
-                    self.do_async(coordinator.update_command_history(data["correlation_id"], result_code))
+                    self.do_async(coordinator.update_command_history(data["correlation_id"], result_code), wait=False)
                 else:
                     _LOGGER.error("No result code")
 

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -851,7 +851,7 @@ class StellantisVehicles(StellantisOauth):
         try:
             if result_code == 11: # MQTT_ERR_AUTH
                 self.do_async(self.scheduled_mqtt_token_refresh(force=True))
-        except:
+        except Exception:
             pass  # refresh_mqtt_token already logs the exception, and raising would halt the Paho reconnect loop
         _LOGGER.debug("---------- END _on_mqtt_disconnect")
 
@@ -924,7 +924,7 @@ class StellantisVehicles(StellantisOauth):
 #                 if programs:
 #                     self.precond_programs[data["vin"]] = data["precond_state"]["programs"]
                 _LOGGER.debug("Update data from mqtt?!?")
-        except (KeyError, Exception) as e:
+        except Exception as e:
             _LOGGER.warning(f"Error: {str(e)}")
         _LOGGER.debug("---------- END _on_mqtt_message")
 
@@ -976,6 +976,6 @@ class StellantisVehicles(StellantisOauth):
             _LOGGER.debug(abrp_request)
             if "status" not in abrp_request or abrp_request["status"] != "ok":
                 _LOGGER.warning(abrp_request)
-        except Exception:
-            pass
+        except Exception as e:
+            _LOGGER.warning("Failed to send ABRP data: %s", e)
         _LOGGER.debug("---------- END send_abrp_data")

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -409,7 +409,7 @@ class StellantisOauth(StellantisBase):
             _LOGGER.debug(token_request)
         except ConfigException as e:
             _LOGGER.debug("---------- END get_mqtt_access_token")
-            raise ConfigEntryAuthFailed(str(e))
+            raise ConfigEntryAuthFailed(str(e)) from e
         except Exception:
             _LOGGER.debug("---------- END get_mqtt_access_token")
             raise

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -961,7 +961,8 @@ class StellantisVehicles(StellantisOauth):
             await self.hass_notify("reconfigure_otp")
             _LOGGER.error("MQTT authentication error. To enable remote commands again please reconfigure the integration")
             _LOGGER.debug("---------- END send_mqtt_message")
-            pass
+            # Re-raise so the caller can trigger Home Assistant's reauth flow.
+            raise
         except Exception as e:
             _LOGGER.error(f"Unexpected error during MQTT message sending: {e}")
             _LOGGER.debug("---------- END send_mqtt_message")


### PR DESCRIPTION
## Summary

Several `except` blocks in the setup, MQTT and OTP code swallowed errors silently (`pass`, or a bare `{}` / empty-list fallback), an MQTT authentication failure while sending a remote command never reached Home Assistant's reauth flow, a failed vehicle-list fetch during setup left the config entry loaded but empty with a misleading "no vehicles" notification, and an unexpected user-info response shape could crash the OTP config-flow step with an unhandled `KeyError`. This PR makes those failures observable and actionable, lets Home Assistant retry a setup that could not reach the API, and stops the paho-mqtt network thread from being blocked inside its own callbacks.

## Changes

| Commit | What |
| --- | --- |
| `Preserve exception context with "from e"` | `otp.py` and `get_mqtt_access_token` chained from the *exception class* (`from KeyError`) or not at all; now chained from the caught instance so tracebacks point at the real cause. `ConfigException` for the missing `defi` field also gets a message. |
| `Raise ConfigException from new_otp instead of a bare Exception` | `new_otp` raised a generic `Exception`; it now raises `ConfigException` (the type the config flow already expects) and re-raises an inner `ConfigException` without re-wrapping it. |
| `Log swallowed exceptions instead of silently discarding them` | The coordinator's last-trip fetch and `send_abrp_data` now log the real error instead of discarding it. Also tidies two `except` clauses (`except:` -> `except Exception:`, redundant `(KeyError, Exception)` tuple). |
| `Re-raise MQTT auth failure so Home Assistant's reauth flow triggers` | `send_mqtt_message` handled `ConfigEntryAuthFailed` (disable remote commands + notify) and then `pass`ed. It now re-raises, so `send_command` reaches its `except ConfigEntryAuthFailed` branch and calls `async_start_reauth()` - HA shows the native reauth card, not just a persistent notification. |
| `Don't block the paho network thread in MQTT callbacks` | `_on_mqtt_disconnect` and the four fire-and-forget `do_async(...)` calls in `_on_mqtt_message` now pass `wait=False`. These run on the paho network thread; blocking it on a token refresh / notification / a 10 s delayed refresh (whose results aren't used) stalled pings and reconnects. Also removes a now-redundant `try/except` around one of those calls. |
| `Fail setup with ConfigEntryNotReady when the vehicle list can't be fetched` | `async_setup_entry` caught every non-auth error and fell back to `vehicles = {}`, so the entry loaded empty (state `LOADED`, no retry) and fired the `no_vehicles_found` notification. It now tears down the half-built entry (`async_shutdown()` + `hass.data` pop, mirroring the first-refresh path) and raises `ConfigEntryNotReady`, so HA retries with backoff. `ConfigEntryAuthFailed` still short-circuits to reauth. |
| `Raise CommunicationError on an empty vehicle-list response` | `get_user_vehicles` returned `[]` both for a genuinely empty account and for an empty / non-object response body on a 2xx. The latter is now raised as `CommunicationError` (caught by the setup handler above and turned into a retry) instead of being reported as an empty account. |
| `Return a list from get_user_info so the config flow can't KeyError` | `get_user_info` returned the raw response; `async_step_otp` then did `user_info_request[0]` outside its `try`, so a non-list body (error object, changed shape) raised an unhandled `KeyError` and aborted the flow with "Unknown error occurred". `get_user_info` now always returns a list (non-list -> `[]`), which the existing `if not user_info_request` check reports as `missing_user_info`. |

## Behavior changes reviewers should note

- On an MQTT auth failure while sending a remote command, HA now surfaces the reauth flow in addition to the existing persistent notification. The previously unreachable `except ConfigEntryAuthFailed` branch in `send_command` is now hit.
- A vehicle-list fetch that fails or returns an empty / invalid body during setup now puts the entry in `SETUP_RETRY` (retried with backoff) instead of loading it empty and showing "no vehicles found". A genuinely empty account (valid response, no vehicles) is unchanged and still shows that notification.
- An unexpected (non-list) response from `get_user_info` during OTP setup / reconfigure now shows the `missing_user_info` config-flow error instead of an unhandled `KeyError` abort.
- Failures that were silent before (last-trip fetch, ABRP push) now log at `WARNING`.
- The paho network thread is no longer blocked inside `_on_mqtt_message` / `_on_mqtt_disconnect`; the command-history update after a successful command is no longer delayed by ~10 s.
- The exception-type / chaining commits carry **no functional change** (the config flow catches broadly) - only better tracebacks and messages.

## Out of scope / possible follow-ups

- `send_abrp_data` now logs at `WARNING` on every poll if the ABRP endpoint is persistently unreachable - could be downgraded to `debug` or made log-once.
- After `disable_remote_commands()` + reauth, the remote-commands checkbox in the options step defaults to off, so the user has to re-enable it manually (pre-existing; the reauth flow could restore the previous value).
