### PR TITLE
Use Home Assistant's shared SSL context for the MQTT connection

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -10,7 +10,6 @@ import json
 from uuid import uuid4
 import asyncio
 from datetime import ( datetime, timedelta )
-import ssl
 import socket
 import random
 
@@ -19,6 +18,11 @@ from homeassistant.helpers import translation
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.components import persistent_notification
 from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.util.ssl import client_context
+# If the Stellantis MQTT broker ever presents a certificate that fails
+# validation, import client_context_no_verify here as well and use it in
+# connect_mqtt() (see the commented line there).
+# from homeassistant.util.ssl import client_context, client_context_no_verify
 
 from .base import StellantisVehicleCoordinator
 from .otp.otp import Otp, save_otp, load_otp, ConfigException
@@ -106,14 +110,6 @@ class MqttClientMod(mqtt.Client):
                 if addr_cnt == 0:
                     raise
 
-
-def _create_ssl_context() -> ssl.SSLContext:
-    """Create a SSL context for the MQTT connection."""
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-    context.load_default_certs()
-    return context
-
-_SSL_CONTEXT = _create_ssl_context()
 
 class StellantisBase:
     def __init__(self, hass: HomeAssistant) -> None:
@@ -812,7 +808,12 @@ class StellantisVehicles(StellantisOauth):
         if self._mqtt is None:
             self._mqtt = MqttClientMod(clean_session=True, protocol=mqtt.MQTTv311)
             # self._mqtt.enable_logger(logger=_LOGGER)
-            self._mqtt.tls_set_context(_SSL_CONTEXT)
+            # Reuse Home Assistant's shared, pre-built client SSL context instead
+            # of building one here (which did blocking cert loading at import).
+            self._mqtt.tls_set_context(client_context())
+            # If the broker's certificate fails validation, swap the line above
+            # for the unverified context (and adjust the import at the top):
+            # self._mqtt.tls_set_context(client_context_no_verify())
             self._mqtt.on_connect = self._on_mqtt_connect
             self._mqtt.on_disconnect = self._on_mqtt_disconnect
             self._mqtt.on_message = self._on_mqtt_message


### PR DESCRIPTION
## What

Replace the integration's own module-level SSL context with Home Assistant's shared client context:

```python
# before  (module import time)
def _create_ssl_context() -> ssl.SSLContext:
    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
    context.load_default_certs()
    return context

_SSL_CONTEXT = _create_ssl_context()
...
self._mqtt.tls_set_context(_SSL_CONTEXT)

# after
from homeassistant.util.ssl import client_context
...
self._mqtt.tls_set_context(client_context())
```

`import ssl` is dropped (now unused).

## Why

1. **Blocking I/O at import.** `context.load_default_certs()` reads the system CA store from disk and ran at module-import time, i.e. inside the event loop while the config entry is being set up.
2. **Deprecated API.** `ssl.PROTOCOL_TLS` has been deprecated since Python 3.10.
3. `homeassistant.util.ssl.client_context()` returns a context Home Assistant builds once at startup and caches (`PROTOCOL_TLS_CLIENT`, certificate verification and hostname checking on, `certifi` CA bundle). Retrieving it is a dict lookup with no I/O, so it is safe to call directly from the event loop and no executor hop is needed.

## Behavior change

The previous context never set `verify_mode` / `check_hostname`, so the MQTT broker's certificate was effectively **not validated**. `client_context()` validates it.

If the Stellantis broker presents a certificate that fails validation, switch to the unverified context: `connect_mqtt()` and the import block both carry a commented `client_context_no_verify()` alternative for exactly this case.

## Testing

Validated manually against my running Home Assistant instance:

- [x] Reload the integration; MQTT (re)connects without TLS errors in the log
- [x] `binary_sensor` for remote commands reports *connected*
- [x] A remote command (e.g. wake up / lock) still round-trips
