### PR TITLE
Handle transient CVS user-vins 50038 error as empty status

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -234,6 +234,14 @@ class StellantisBase:
                         _LOGGER.warning(error)
                         _LOGGER.debug("---------- END make_http_request")
                         return {}
+                    if str(resp.status).startswith("500") and str(result.get("code")) == "50038":
+                        # CVS error/user-vins - 50038: a transient Stellantis backend
+                        # failure while resolving the account's VIN list. Treat it like
+                        # an empty status so the coordinator keeps the last known data
+                        # for a few cycles instead of dropping every entity.
+                        _LOGGER.warning(error)
+                        _LOGGER.debug("---------- END make_http_request")
+                        return {}
                     if str(resp.status) == "500" and str(result.get("code")) == "50000":
                         # Connection module replaced (https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/388)
                         # https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/pull/475


### PR DESCRIPTION
## Problem

Sometimes the Stellantis vehicle-status endpoint returns HTTP 500 with this body: `{"message": "CVS error/user-vins", "code": 50038}`. This is a temporary error on the Stellantis side: their backend fails to look up the list of VINs for the account. It usually recovers by itself after one or two polls. Right now `make_http_request` does not know this case, so it falls through to the generic `str(resp.status).startswith("50")` branch and raises `CommunicationError`. The coordinator turns that into an `UpdateFailed`, so all entities of the affected vehicle go `unavailable` until the next good poll, and one error line is logged for the outage.

EDIT: `(CVS = Connected Vehicle Services)`

## Change

Add a specific branch in `make_http_request` for HTTP `500` with `code == "50038"`. It logs the error as a warning and returns `{}`. This is the same approach already used for the `404 / 40400` "status not found" case.

## Resulting behavior

An empty result (`{}`) is handled by the coordinator's empty-status path. The last known data is kept for the first `EMPTY_STATUS_LIMIT - 1` empty responses in a row. Only when the `EMPTY_STATUS_LIMIT`-th one arrives does the update fail with `UpdateFailed`. `_reconcile_vehicle()` still runs on every `EMPTY_STATUS_LIMIT`-th empty response, so a vehicle that was really unpaired is still detected. Short Stellantis outages no longer make the entities go `unavailable`. A long outage still ends in `UpdateFailed`, just a few cycles later.
