### PR TITLE
Run blocking MQTT `connect()` in the executor

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -821,7 +821,10 @@ class StellantisVehicles(StellantisOauth):
             self._mqtt.disconnect()
         self._mqtt.username_pw_set("IMA_OAUTH_ACCESS_TOKEN", self.get_config("mqtt")["access_token"])
         try:
-            self._mqtt.connect(MQTT_SERVER, MQTT_PORT, MQTT_KEEP_ALIVE_S)
+            # paho's connect() does blocking DNS + TCP + TLS handshake, so run it in the executor to keep the event loop responsive.
+            await self._hass.async_add_executor_job(
+                self._mqtt.connect, MQTT_SERVER, MQTT_PORT, MQTT_KEEP_ALIVE_S
+            )
             self._mqtt.loop_start() # Under the hood, this will call loop_forever in a thread, which means that the thread will terminate if we call disconnect()
         except Exception as e:
             _LOGGER.warning(f"Error: {str(e)}")


### PR DESCRIPTION
## Summary

`connect_mqtt()` is an async method, but it calls `paho.mqtt.client.Client.connect()` directly on the event loop. That call is fully synchronous: it resolves DNS (`socket.getaddrinfo`), opens the TCP socket and runs the TLS handshake before returning. When the broker is slow or unreachable the event loop is blocked until the socket timeout expires, which stalls every other integration running in the same process.

This wraps the `connect()` call in `hass.async_add_executor_job()` so the blocking network work runs in a worker thread. `loop_start()` stays on the event loop because it only spawns the paho network thread and returns immediately; keeping it there also preserves the `connect()` → `loop_start()` ordering.

## Behavior

No functional change. Exceptions raised by `connect()` still propagate through `await` into the same `except Exception` handler as before.

## Testing

Manually verified against my running Home Assistant instance: reload the integration with remote commands enabled, confirm the MQTT client connects and the remote command entities become available.
