### PR TITLE
Streamline debug logging

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -146,24 +146,24 @@ async def async_remove_entry(hass: HomeAssistant, config: ConfigEntry) -> None:
 
         # Remove OTP file if it exists
         if os.path.isfile(otp_file_path):
-            _LOGGER.debug(f"Deleting OTP-File: {otp_file_path}")
+            _LOGGER.debug("Deleting OTP file: %s", otp_file_path)
             os.remove(otp_file_path)
 
         # Remove storage folder if empty
         if os.path.exists(storage_path) and os.path.isdir(storage_path) and not os.listdir(storage_path):
-            _LOGGER.debug(f"Deleting empty Stellantis storage folder: {storage_path}")
+            _LOGGER.debug("Deleting empty Stellantis storage folder: %s", storage_path)
             shutil.rmtree(storage_path)
 
         # Remove Stellantis image folder of this entry
         entry_image_path = os.path.join(hass_config_path, "www", DOMAIN, config.unique_id)
         if os.path.exists(entry_image_path) and os.path.isdir(entry_image_path):
-            _LOGGER.debug(f"Deleting Stellantis entry image folder: {entry_image_path}")
+            _LOGGER.debug("Deleting Stellantis entry image folder: %s", entry_image_path)
             shutil.rmtree(entry_image_path)
 
         # Remove Stellantis image folder if empty
         image_path = os.path.join(hass_config_path, "www", DOMAIN)
         if os.path.exists(image_path) and os.path.isdir(image_path) and not os.listdir(image_path):
-            _LOGGER.debug(f"Deleting Stellantis image folder: {image_path}")
+            _LOGGER.debug("Deleting Stellantis image folder: %s", image_path)
             shutil.rmtree(image_path)
 
 
@@ -176,7 +176,7 @@ async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):
         # update unique_id with customer_id - used to be data[FIELD_MOBILE_APP].lower()+str(self.data["access_token"][:5])
         new_unique_id = config.data.get("customer_id")
         if config.unique_id != new_unique_id:
-            _LOGGER.debug(f"Migrating unique_id from {config.unique_id} to {new_unique_id}")
+            _LOGGER.debug("Migrating unique_id from %s to %s", config.unique_id, new_unique_id)
             hass.config_entries.async_update_entry(config, unique_id=new_unique_id)
         # Migrate to new file structure - Generate path to storage folder and move OTP file
         hass_config_path = hass.config.path()
@@ -188,7 +188,7 @@ async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):
             if not os.path.isdir(new_storage_path):
                 os.mkdir(new_storage_path)
             if not os.path.isfile(new_otp_file_path):
-                _LOGGER.debug(f"Migrating OTP file to new storage path from {old_otp_file_path} to {new_otp_file_path}")
+                _LOGGER.debug("Migrating OTP file to new storage path from %s to %s", old_otp_file_path, new_otp_file_path)
                 os.rename(old_otp_file_path, new_otp_file_path)
             else:
                 os.remove(old_otp_file_path)
@@ -203,7 +203,7 @@ async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):
         public_path = hass.config.path("www")
         old_image_path = f"{public_path}/stellantis-vehicles"
         if os.path.isdir(old_image_path):
-            _LOGGER.debug(f"Deleting Stellantis old image folder: {old_image_path}")
+            _LOGGER.debug("Deleting Stellantis old image folder: %s", old_image_path)
             shutil.rmtree(old_image_path)
         hass.config_entries.async_update_entry(config, version=target_version, minor_version=target_minor_version)
         _LOGGER.debug("Migration to configuration version %s.%s successful", config.version, config.minor_version)

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -60,7 +60,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
     @log_call
     async def _async_update_data(self):
         """ Update vehicle data from Stellantis. """
-        _LOGGER.debug(self._config)
+        _LOGGER.debug("Coordinator config: %s", self._config)
 
         if self._phase_offset:
             # The one-time startup stagger has been consumed, go back to the

--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -19,7 +19,7 @@ from homeassistant.const import ( STATE_UNAVAILABLE, STATE_UNKNOWN, STATE_ON, ST
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 
-from .utils import ( time_from_pt_string, get_datetime, date_from_pt_string, time_from_string, rate_limit )
+from .utils import ( time_from_pt_string, get_datetime, date_from_pt_string, time_from_string, rate_limit, log_call )
 
 from .const import (
     DOMAIN,
@@ -57,9 +57,9 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         if self._stellantis.logger_filter:
             _LOGGER.addFilter(self._stellantis.logger_filter)
 
+    @log_call
     async def _async_update_data(self):
         """ Update vehicle data from Stellantis. """
-        _LOGGER.debug("---------- START _async_update_data")
         _LOGGER.debug(self._config)
 
         if self._phase_offset:
@@ -76,11 +76,9 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         try:
             new_data = await self._stellantis.get_vehicle_status(self._vehicle)
         except ConfigEntryAuthFailed:
-            _LOGGER.debug("---------- END _async_update_data")
             raise
         except Exception as err:
             _LOGGER.debug("Error communicating with Stellantis API: %s", err)
-            _LOGGER.debug("---------- END _async_update_data")
             raise UpdateFailed("Error communicating with Stellantis API") from err
 
         if not new_data:
@@ -94,7 +92,6 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
 
             if self._empty_status_count < EMPTY_STATUS_LIMIT:
                 # Short gap: keep the last known data.
-                _LOGGER.debug("---------- END _async_update_data")
                 return
 
             if self._empty_status_count % EMPTY_STATUS_LIMIT == 0 and not self._vehicle_removed:
@@ -102,7 +99,6 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
                 await self._reconcile_vehicle()
 
             # Sustained outage: surface it so entities go unavailable.
-            _LOGGER.debug("---------- END _async_update_data")
             raise UpdateFailed("Empty vehicle status response")
 
         self._empty_status_count = 0
@@ -122,12 +118,10 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             else:
                 if new_dt <= current_dt:
                     _LOGGER.debug("API did not return updated vehicle data, skipping sensor update")
-                    _LOGGER.debug("---------- END _async_update_data")
                     return
 
         self._data = new_data
         await self.after_async_update_data()
-        _LOGGER.debug("---------- END _async_update_data")
 
     def stagger_first_poll(self, offset_seconds):
         """ Push this vehicle's next poll back once so several vehicles do not all

--- a/custom_components/stellantis_vehicles/config_flow.py
+++ b/custom_components/stellantis_vehicles/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     CONF_EMAIL
 )
 
-from .utils import get_datetime
+from .utils import get_datetime, log_call
 from .stellantis import StellantisOauth
 from .const import (
     DOMAIN,
@@ -312,12 +312,11 @@ class StellantisVehiclesConfigFlow(ConfigFlow, domain=DOMAIN):
             return await self.async_step_options()
 
 
+    @log_call
     async def async_step_reauth(self, entry_data):
-        _LOGGER.debug("---------- START async_step_reauth")
         self.data.update({FIELD_MOBILE_APP: entry_data[FIELD_MOBILE_APP], FIELD_COUNTRY_CODE: entry_data[FIELD_COUNTRY_CODE]})
         if FIELD_OAUTH_CODE_URL in entry_data:
             self.data.update({FIELD_OAUTH_CODE_URL: entry_data[FIELD_OAUTH_CODE_URL]})
-        _LOGGER.debug("---------- END async_step_reauth")
         return await self.async_step_reauth_confirm()
 
 

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -26,7 +26,7 @@ from homeassistant.util.ssl import client_context
 
 from .base import StellantisVehicleCoordinator
 from .otp.otp import Otp, save_otp, load_otp, ConfigException
-from .utils import ( get_datetime, rate_limit, SensitiveDataFilter, replace_string_placeholders )
+from .utils import ( get_datetime, rate_limit, SensitiveDataFilter, replace_string_placeholders, log_call )
 from .exceptions import ( CommunicationError, RateLimitException )
 
 from .const import (
@@ -198,9 +198,9 @@ class StellantisBase:
         query_params = '&'.join(query_params)
         return self.replace_placeholders(f"{url}?{query_params}", vehicle)
 
+    @log_call
     async def make_http_request(self, url, method='GET', headers=None, params=None, json_data=None, data=None, timeout=60):
         """Perform an HTTP request and return the decoded JSON response."""
-        _LOGGER.debug("---------- START make_http_request")
         self.start_session()
         try:
             _timeout = aiohttp.ClientTimeout(total=timeout)
@@ -228,7 +228,6 @@ class StellantisBase:
                     if str(resp.status) == "404" and str(result.get("code")) == "40400":
                         # Not Found: We didn't find the status for this vehicle. - 40400
                         _LOGGER.warning(error)
-                        _LOGGER.debug("---------- END make_http_request")
                         return {}
                     if str(resp.status).startswith("500") and str(result.get("code")) == "50038":
                         # CVS error/user-vins - 50038: a transient Stellantis backend
@@ -236,7 +235,6 @@ class StellantisBase:
                         # an empty status so the coordinator keeps the last known data
                         # for a few cycles instead of dropping every entity.
                         _LOGGER.warning(error)
-                        _LOGGER.debug("---------- END make_http_request")
                         return {}
                     if str(resp.status) == "500" and str(result.get("code")) == "50000":
                         # Connection module replaced (https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/388)
@@ -254,28 +252,23 @@ class StellantisBase:
                     # Any other non-2xx response we don't have a specific case for
                     raise CommunicationError(error or f"Unexpected HTTP status {resp.status}")
 
-                _LOGGER.debug("---------- END make_http_request")
                 return result
         except asyncio.TimeoutError as e:
             await self.close_session()
             _LOGGER.warning(f"Error: {e}")
-            _LOGGER.debug("---------- END make_http_request")
             # Connection error
             raise CommunicationError("Request timeout") from e
         except aiohttp.client_exceptions.ClientError as e:
             await self.close_session()
             _LOGGER.warning(f"Error: {e}")
-            _LOGGER.debug("---------- END make_http_request")
             # Connection error
             raise CommunicationError(e) from e
         except (ConfigEntryAuthFailed, CommunicationError):
             await self.close_session()
-            _LOGGER.debug("---------- END make_http_request")
             raise
         except Exception as e:
             await self.close_session()
             _LOGGER.warning(f"Error: {e}")
-            _LOGGER.debug("---------- END make_http_request")
             raise
 
     def do_async(self, async_func, delay=0, wait=True):
@@ -331,17 +324,16 @@ class StellantisOauth(StellantisBase):
     def get_oauth_url(self):
         return self.apply_query_params(OAUTH_AUTHORIZE_URL, OAUTH_AUTHORIZE_QUERY_PARAMS)
 
+    @log_call
     async def get_oauth_code(self, email, password, code_url=None):
-        _LOGGER.debug("---------- START get_oauth_code")
         oauth_code_request = await self.make_http_request(code_url or OAUTH_CODE_URL, 'POST', None, None, {"url": self.get_oauth_url(), "email": email, "password": password}, None, 300)
         if "code" in oauth_code_request:
             self.logger_filter.add_custom_value(oauth_code_request["code"])
         _LOGGER.debug(oauth_code_request)
-        _LOGGER.debug("---------- END get_oauth_code")
         return oauth_code_request
 
+    @log_call
     async def get_access_token(self):
-        _LOGGER.debug("---------- START get_access_token")
         url = self.apply_query_params(OAUTH_TOKEN_URL, OAUTH_GET_TOKEN_QUERY_PARAMS)
         headers = self.apply_dict_params(OAUTH_TOKEN_HEADERS)
         token_request = await self.make_http_request(url, 'POST', headers)
@@ -354,11 +346,10 @@ class StellantisOauth(StellantisBase):
         _LOGGER.debug(url)
         _LOGGER.debug(headers)
         _LOGGER.debug(token_request)
-        _LOGGER.debug("---------- END get_access_token")
         return token_request
 
+    @log_call
     async def get_user_info(self):
-        _LOGGER.debug("---------- START get_user_info")
         url = self.apply_query_params(GET_USER_INFO_URL, CLIENT_ID_QUERY_PARAMS)
         headers = self.apply_dict_params(GET_OTP_HEADERS)
         headers["x-transaction-id"] = "1234"
@@ -370,7 +361,6 @@ class StellantisOauth(StellantisBase):
         _LOGGER.debug(url)
         _LOGGER.debug(headers)
         _LOGGER.debug(user_request)
-        _LOGGER.debug("---------- END get_user_info")
         # Always hand back a list so callers can safely index [0]; a non-list
         # body (error object, changed shape) becomes an empty list, which the
         # config flow reports as missing user info.
@@ -392,19 +382,18 @@ class StellantisOauth(StellantisBase):
             _LOGGER.error(str(e))
             raise ConfigException(str(e)) from e
 
+    @log_call
     async def get_otp_sms(self):
-        _LOGGER.debug("---------- START get_otp_sms")
         url = self.apply_query_params(GET_OTP_URL, CLIENT_ID_QUERY_PARAMS)
         headers = self.apply_dict_params(GET_OTP_HEADERS)
         sms_request = await self.make_http_request(url, 'POST', headers)
         _LOGGER.debug(url)
         _LOGGER.debug(headers)
         _LOGGER.debug(sms_request)
-        _LOGGER.debug("---------- END get_otp_sms")
         return sms_request
 
+    @log_call
     async def get_mqtt_access_token(self):
-        _LOGGER.debug("---------- START get_mqtt_access_token")
         url = self.apply_query_params(GET_MQTT_TOKEN_URL, CLIENT_ID_QUERY_PARAMS)
         headers = self.apply_dict_params(GET_OTP_HEADERS)
         try:
@@ -418,17 +407,12 @@ class StellantisOauth(StellantisBase):
             _LOGGER.debug(headers)
             _LOGGER.debug(token_request)
         except ConfigException as e:
-            _LOGGER.debug("---------- END get_mqtt_access_token")
             raise ConfigEntryAuthFailed(str(e)) from e
-        except Exception:
-            _LOGGER.debug("---------- END get_mqtt_access_token")
-            raise
-        _LOGGER.debug("---------- END get_mqtt_access_token")
         return token_request
 
+    @log_call
     @rate_limit(6, 86400) # 6 per 1 day
     async def get_otp_code(self):
-        _LOGGER.debug("---------- START get_otp_code")
         # Check if storage path exists, if not create it
         hass_config_path = self._hass.config.path()
         storage_path = os.path.join(hass_config_path, ".storage", DOMAIN)
@@ -441,18 +425,15 @@ class StellantisOauth(StellantisBase):
         if self.otp is None:
             if not os.path.isfile(otp_file_path):
                 _LOGGER.error(f"Error: OTP file '{otp_file_path}' not found, please reauthenticate")
-                _LOGGER.debug("---------- END get_otp_code")
                 raise ConfigEntryAuthFailed("OTP file not found, please reauthenticate")
             self.otp = await self._hass.async_add_executor_job(load_otp, otp_file_path)
         # Get the OTP code using OTP object. It seems there is a rate limit of 6 requests per 24h
         otp_code = await self._hass.async_add_executor_job(self.otp.get_otp_code)
         if otp_code is None:
             _LOGGER.error("Error: OTP code is empty, please reauthenticate")
-            _LOGGER.debug("---------- END get_otp_code")
             raise ConfigEntryAuthFailed("OTP code is empty, please reauthenticate")
         # Save updated OTP object to file
         await self._hass.async_add_executor_job(save_otp, self.otp, otp_file_path)
-        _LOGGER.debug("---------- END get_otp_code")
         return otp_code
 
 
@@ -605,8 +586,8 @@ class StellantisVehicles(StellantisOauth):
         await self.scheduled_oauth_token_refresh()
         await self.scheduled_mqtt_token_refresh()
 
+    @log_call
     async def scheduled_oauth_token_refresh(self, now=None):
-        _LOGGER.debug("---------- START scheduled_oauth_token_refresh")
         def get_next_run():
             expires_in = self.get_config("oauth")["expires_in"]
             return datetime.fromisoformat(expires_in) - timedelta(minutes=5)
@@ -626,11 +607,10 @@ class StellantisVehicles(StellantisOauth):
         _LOGGER.debug(f"Next refresh: {next_run}")
         next_job = HassJob(self.scheduled_oauth_token_refresh, f"{DOMAIN} refresh oauth token: {next_run}", cancel_on_shutdown=True)
         self._oauth_token_scheduled = async_track_point_in_time(self._hass, next_job, next_run)
-        _LOGGER.debug("---------- END scheduled_oauth_token_refresh")
 
+    @log_call
     @rate_limit(6, 1800) # 6 per 30 min
     async def refresh_token_request(self):
-        _LOGGER.debug("---------- START refresh_token_request")
         url = self.apply_query_params(OAUTH_TOKEN_URL, OAUTH_REFRESH_TOKEN_QUERY_PARAMS)
         headers = self.apply_dict_params(OAUTH_TOKEN_HEADERS)
         token_request = await self.make_http_request(url, 'POST', headers)
@@ -646,10 +626,9 @@ class StellantisVehicles(StellantisOauth):
         }
         self.save_config({"oauth": new_config})
         self.update_stored_config("oauth", new_config)
-        _LOGGER.debug("---------- END refresh_token_request")
 
+    @log_call
     async def get_user_vehicles(self, force=False):
-        _LOGGER.debug("---------- START get_user_vehicles")
         if force:
             # Drop the cache so the account vehicle list is fetched again, e.g. to
             # confirm a vehicle was unpaired without restarting Home Assistant.
@@ -695,11 +674,10 @@ class StellantisVehicles(StellantisOauth):
                     _LOGGER.warning("No vehicles found in vehicles_request['_embedded']")
             else:
                 _LOGGER.warning("No _embedded found in vehicles_request")
-        _LOGGER.debug("---------- END get_user_vehicles")
         return self._vehicles
 
+    @log_call
     async def get_vehicle_status(self, vehicle):
-        _LOGGER.debug("---------- START get_vehicle_status")
         # Ensure that the MQTT client is connected
         if self.remote_commands and (self._mqtt is None or self._mqtt.is_connected() is False):
             _LOGGER.debug("MQTT client is not connected, try to connect it")
@@ -711,11 +689,10 @@ class StellantisVehicles(StellantisOauth):
         _LOGGER.debug(url)
         _LOGGER.debug(headers)
         _LOGGER.debug(vehicle_status_request)
-        _LOGGER.debug("---------- END get_vehicle_status")
         return vehicle_status_request
 
+    @log_call
     async def get_vehicle_last_trip(self, vehicle, page_token=None):
-        _LOGGER.debug("---------- START get_vehicle_last_trip")
         url = self.apply_query_params(CAR_API_GET_VEHICLE_TRIPS_URL, CLIENT_ID_QUERY_PARAMS, vehicle)
         headers = self.apply_dict_params(CAR_API_HEADERS)
         limit_date = (get_datetime() - timedelta(days=1)).isoformat(timespec="seconds")
@@ -732,9 +709,7 @@ class StellantisVehicles(StellantisOauth):
         if last_href and last_href != self_href:
             next_page_token = last_href.split("pageToken=")[-1]
             if next_page_token != page_token:
-                _LOGGER.debug("---------- END get_vehicle_last_trip")
                 return await self.get_vehicle_last_trip(vehicle, next_page_token)
-        _LOGGER.debug("---------- END get_vehicle_last_trip")
         return vehicle_trips_request
 
 #     async def get_vehicle_trips(self, page_token=False):
@@ -751,10 +726,10 @@ class StellantisVehicles(StellantisOauth):
 #         _LOGGER.debug("---------- END get_vehicle_trips")
 #         return vehicle_trips_request
 
+    @log_call
     async def scheduled_mqtt_token_refresh(self, now=None, force=False):
         if not self.remote_commands:
             return
-        _LOGGER.debug("---------- START scheduled_mqtt_token_refresh")
         def get_next_run():
             mqtt_config = self.get_config("mqtt")
             expires_in = mqtt_config["expires_in"]
@@ -773,16 +748,14 @@ class StellantisVehicles(StellantisOauth):
             self.disable_remote_commands()
             await self.hass_notify("reconfigure_otp")
             _LOGGER.error("MQTT authentication error. To enable remote commands again please reconfigure the integration")
-            _LOGGER.debug("---------- END scheduled_mqtt_token_refresh")
             return
         _LOGGER.debug(f"Current time: {get_datetime()}")
         _LOGGER.debug(f"Next refresh: {next_run}")
         next_job = HassJob(self.scheduled_mqtt_token_refresh, f"{DOMAIN} refresh mqtt token: {next_run}", cancel_on_shutdown=True)
         self._mqtt_token_scheduled = async_track_point_in_time(self._hass, next_job, next_run)
-        _LOGGER.debug("---------- END scheduled_mqtt_token_refresh")
 
+    @log_call
     async def refresh_mqtt_token_request(self, access_token_only=False):
-        _LOGGER.debug("---------- START refresh_mqtt_token_request")
         url = self.apply_query_params(GET_MQTT_TOKEN_URL, CLIENT_ID_QUERY_PARAMS)
         headers = self.apply_dict_params(GET_OTP_HEADERS)
         mqtt_config = self.get_config("mqtt")
@@ -806,7 +779,6 @@ class StellantisVehicles(StellantisOauth):
         _LOGGER.debug(token_request)
         if not "access_token" in token_request:
             _LOGGER.warning("Refreshing mqtt access_token failed (no access_token in response)")
-            _LOGGER.debug("---------- END refresh_mqtt_token_request")
             return None
         mqtt_config["access_token"] = token_request["access_token"]
         mqtt_config["expires_in"] = (get_datetime() + timedelta(seconds=int(token_request["expires_in"]))).isoformat()
@@ -815,14 +787,12 @@ class StellantisVehicles(StellantisOauth):
             mqtt_config["refresh_token_expires_at"] = (get_datetime() + timedelta(minutes=int(MQTT_REFRESH_TOKEN_TTL))).isoformat()
         self.save_config({"mqtt": mqtt_config})
         self.update_stored_config("mqtt", mqtt_config)
-        _LOGGER.debug("---------- END refresh_mqtt_token_request")
 
+    @log_call
     async def connect_mqtt(self):
-        _LOGGER.debug("---------- START connect_mqtt")
         if self._shutting_down:
             # A coordinator refresh still in flight during unload must not
             # recreate the MQTT client async_shutdown just tore down.
-            _LOGGER.debug("---------- END connect_mqtt")
             return False
         if self._mqtt is None:
             self._mqtt = MqttClientMod(clean_session=True, protocol=mqtt.MQTTv311)
@@ -848,11 +818,10 @@ class StellantisVehicles(StellantisOauth):
             self._mqtt.loop_start() # Under the hood, this will call loop_forever in a thread, which means that the thread will terminate if we call disconnect()
         except Exception as e:
             _LOGGER.warning(f"Error: {str(e)}")
-        _LOGGER.debug("---------- END connect_mqtt")
         return self._mqtt.is_connected()
 
+    @log_call
     def _on_mqtt_connect(self, client, userdata, result_code, _):
-        _LOGGER.debug("---------- START _on_mqtt_connect")
         _LOGGER.debug(f"Code: {result_code}")
         try:
             topics = [MQTT_RESP_TOPIC + self.get_config("customer_id") + "/#"]
@@ -863,20 +832,18 @@ class StellantisVehicles(StellantisOauth):
                 _LOGGER.debug(f"Topic: {topic}")
         except Exception as e:
             _LOGGER.warning(f"Error: {str(e)}")
-        _LOGGER.debug("---------- END _on_mqtt_connect")
 
+    @log_call
     def _on_mqtt_disconnect(self, client, userdata, result_code):
-        _LOGGER.debug("---------- START _on_mqtt_disconnect")
         _LOGGER.debug(f"Code: {result_code} -> {mqtt.error_string(result_code)}")
         if result_code == 11: # MQTT_ERR_AUTH
             # Runs on the paho network thread; wait=False keeps the reconnect loop
             # from blocking on the token refresh (network I/O, no timeout).
             # do_async already guards shutdown and the coroutine logs its own errors.
             self.do_async(self.scheduled_mqtt_token_refresh(force=True), wait=False)
-        _LOGGER.debug("---------- END _on_mqtt_disconnect")
 
+    @log_call
     def _on_mqtt_subscribe(self, client, userdata, mid, granted_qos):
-        _LOGGER.debug("---------- START _on_mqtt_subscribe")
         try:
             if any(qos == 0x80 for qos in granted_qos):
                 _LOGGER.warning("Subscription failed, will try to reconnect MQTT in 300 seconds")
@@ -888,10 +855,9 @@ class StellantisVehicles(StellantisOauth):
                 _LOGGER.debug(f"Completed (QoS: {granted_qos})")
         except Exception as e:
             _LOGGER.warning(f"Error: {str(e)}")
-        _LOGGER.debug("---------- END _on_mqtt_subscribe")
 
+    @log_call
     def _on_mqtt_message(self, client, userdata, msg):
-        _LOGGER.debug("---------- START _on_mqtt_message")
         try:
             _LOGGER.debug(f"Message: {msg.topic} {msg.payload} {msg.qos}")
             data = json.loads(msg.payload)
@@ -902,8 +868,7 @@ class StellantisVehicles(StellantisOauth):
                     coordinator = self.async_get_coordinator_by_action_id(data["correlation_id"])
 
                 if not coordinator:
-                    _LOGGER.error("No coordinator found by vin o correlation_id")
-                    _LOGGER.debug("---------- END _on_mqtt_message")
+                    _LOGGER.error("No coordinator found by vin or correlation_id")
                     return
 
                 result_code = None
@@ -924,7 +889,6 @@ class StellantisVehicles(StellantisOauth):
                             # retry forces a token refresh; the result comes back as a
                             # fresh MQTT response and send_mqtt_message logs its own errors
                             self.do_async(self.send_mqtt_message(last_request[0], last_request[1], coordinator._vehicle, False, data["correlation_id"]), wait=False)
-                            _LOGGER.debug("---------- END _on_mqtt_message")
                             return
                         else:
                             _LOGGER.warning("Last request was sent twice without success")
@@ -951,10 +915,9 @@ class StellantisVehicles(StellantisOauth):
                 _LOGGER.debug("Update data from mqtt?!?")
         except Exception as e:
             _LOGGER.warning(f"Error: {str(e)}")
-        _LOGGER.debug("---------- END _on_mqtt_message")
 
+    @log_call
     async def send_mqtt_message(self, service, message, vehicle, store=True, action_id=None):
-        _LOGGER.debug("---------- START send_mqtt_message")
         # we need to refresh the token if it is expired, either here upfront or in the mqtt callback '_on_mqtt_message' in case of result_code 400
         try:
             await self.scheduled_mqtt_token_refresh(force=(store == False))
@@ -979,22 +942,19 @@ class StellantisVehicles(StellantisOauth):
                 action_id = None
             if store:
                 self._mqtt_last_request = [service, message]
-            _LOGGER.debug("---------- END send_mqtt_message")
             return action_id
         except ConfigEntryAuthFailed:
             self.disable_remote_commands()
             await self.hass_notify("reconfigure_otp")
             _LOGGER.error("MQTT authentication error. To enable remote commands again please reconfigure the integration")
-            _LOGGER.debug("---------- END send_mqtt_message")
             # Re-raise so the caller can trigger Home Assistant's reauth flow.
             raise
         except Exception as e:
             _LOGGER.error(f"Unexpected error during MQTT message sending: {e}")
-            _LOGGER.debug("---------- END send_mqtt_message")
             raise
 
+    @log_call
     async def send_abrp_data(self, params):
-        _LOGGER.debug("---------- START send_abrp_data")
         params["api_key"] = ABRP_API_KEY
         _LOGGER.debug(params)
         try:
@@ -1004,4 +964,3 @@ class StellantisVehicles(StellantisOauth):
                 _LOGGER.warning(abrp_request)
         except Exception as e:
             _LOGGER.warning("Failed to send ABRP data: %s", e)
-        _LOGGER.debug("---------- END send_abrp_data")

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -275,9 +275,9 @@ class StellantisBase:
         except (ConfigEntryAuthFailed, CommunicationError):
             await self.close_session()
             raise
-        except Exception as e:
+        except Exception:
             await self.close_session()
-            _LOGGER.warning(f"Error: {e}")
+            _LOGGER.exception("Unexpected error during request to %s", url)
             raise
 
     def do_async(self, async_func, delay=0, wait=True):
@@ -819,8 +819,8 @@ class StellantisVehicles(StellantisOauth):
             for topic in topics:
                 client.subscribe(topic, qos=MQTT_QOS)
                 _LOGGER.debug("Subscribed to MQTT topic %s", topic)
-        except Exception as e:
-            _LOGGER.warning(f"Error: {str(e)}")
+        except Exception:
+            _LOGGER.exception("Error while subscribing to MQTT topics")
 
     @log_call
     def _on_mqtt_disconnect(self, client, userdata, result_code):
@@ -842,8 +842,8 @@ class StellantisVehicles(StellantisOauth):
                 self.do_async(self.connect_mqtt(), 300, wait=False)
             else:
                 _LOGGER.debug("MQTT subscription completed (QoS: %s)", granted_qos)
-        except Exception as e:
-            _LOGGER.warning(f"Error: {str(e)}")
+        except Exception:
+            _LOGGER.exception("Error in MQTT subscribe callback")
 
     @log_call
     def _on_mqtt_message(self, client, userdata, msg):
@@ -902,8 +902,8 @@ class StellantisVehicles(StellantisOauth):
 #                 if programs:
 #                     self.precond_programs[data["vin"]] = data["precond_state"]["programs"]
                 _LOGGER.debug("Update data from mqtt?!?")
-        except Exception as e:
-            _LOGGER.warning(f"Error: {str(e)}")
+        except Exception:
+            _LOGGER.exception("Error while handling MQTT message")
 
     @log_call
     async def send_mqtt_message(self, service, message, vehicle, store=True, action_id=None):
@@ -937,8 +937,8 @@ class StellantisVehicles(StellantisOauth):
             _LOGGER.error("MQTT authentication error. To enable remote commands again please reconfigure the integration")
             # Re-raise so the caller can trigger Home Assistant's reauth flow.
             raise
-        except Exception as e:
-            _LOGGER.error(f"Unexpected error during MQTT message sending: {e}")
+        except Exception:
+            _LOGGER.exception("Unexpected error during MQTT message sending")
             raise
 
     @log_call

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -70,6 +70,17 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _log_http_exchange(url, headers, response, **extra):
+    """Debug-log an HTTP request and its decoded response as a single record."""
+    if not _LOGGER.isEnabledFor(logging.DEBUG):
+        return
+    details = "".join(f" {key}={value!r}" for key, value in extra.items())
+    _LOGGER.debug(
+        "HTTP exchange | url=%s headers=%s%s | response=%s",
+        url, headers, details, response,
+    )
+
+
 # Some Stellantis MQTT servers drop packets with a TCP payload greater than 1456 bytes
 # which causes the TLS handshake to fail and later a "Connnection reset by peer" error.
 # As a workaround, we modify the MQTT client to reduce the MSS before connecting the TCP socket
@@ -218,12 +229,10 @@ class StellantisBase:
                     elif "message" in result and "code" in result:
                         error = result["message"] + " - " + str(result["code"])
 
-                    _LOGGER.debug(f"{method} request error {str(resp.status)}: {resp.url}")
-                    _LOGGER.debug(headers)
-                    _LOGGER.debug(params)
-                    _LOGGER.debug(json_data)
-                    _LOGGER.debug(data)
-                    _LOGGER.debug(result)
+                    _LOGGER.debug(
+                        "HTTP %s %s failed with status %s | headers=%s params=%s json=%s data=%s | response=%s",
+                        method, resp.url, resp.status, headers, params, json_data, data, result,
+                    )
 
                     if str(resp.status) == "404" and str(result.get("code")) == "40400":
                         # Not Found: We didn't find the status for this vehicle. - 40400
@@ -329,7 +338,7 @@ class StellantisOauth(StellantisBase):
         oauth_code_request = await self.make_http_request(code_url or OAUTH_CODE_URL, 'POST', None, None, {"url": self.get_oauth_url(), "email": email, "password": password}, None, 300)
         if "code" in oauth_code_request:
             self.logger_filter.add_custom_value(oauth_code_request["code"])
-        _LOGGER.debug(oauth_code_request)
+        _LOGGER.debug("OAuth code response: %s", oauth_code_request)
         return oauth_code_request
 
     @log_call
@@ -343,9 +352,7 @@ class StellantisOauth(StellantisBase):
             self.logger_filter.add_custom_value(token_request["refresh_token"])
         if "id_token" in token_request:
             self.logger_filter.add_custom_value(token_request["id_token"])
-        _LOGGER.debug(url)
-        _LOGGER.debug(headers)
-        _LOGGER.debug(token_request)
+        _log_http_exchange(url, headers, token_request)
         return token_request
 
     @log_call
@@ -358,9 +365,7 @@ class StellantisOauth(StellantisBase):
         for key in ("customer", "vehicle", "car_association_id"):
             if key in user_info:
                 self.logger_filter.add_custom_value(user_info[key])
-        _LOGGER.debug(url)
-        _LOGGER.debug(headers)
-        _LOGGER.debug(user_request)
+        _log_http_exchange(url, headers, user_request)
         # Always hand back a list so callers can safely index [0]; a non-list
         # body (error object, changed shape) becomes an empty list, which the
         # config flow reports as missing user info.
@@ -387,9 +392,7 @@ class StellantisOauth(StellantisBase):
         url = self.apply_query_params(GET_OTP_URL, CLIENT_ID_QUERY_PARAMS)
         headers = self.apply_dict_params(GET_OTP_HEADERS)
         sms_request = await self.make_http_request(url, 'POST', headers)
-        _LOGGER.debug(url)
-        _LOGGER.debug(headers)
-        _LOGGER.debug(sms_request)
+        _log_http_exchange(url, headers, sms_request)
         return sms_request
 
     @log_call
@@ -403,9 +406,7 @@ class StellantisOauth(StellantisBase):
                 self.logger_filter.add_custom_value(token_request["access_token"])
             if "refresh_token" in token_request:
                 self.logger_filter.add_custom_value(token_request["refresh_token"])
-            _LOGGER.debug(url)
-            _LOGGER.debug(headers)
-            _LOGGER.debug(token_request)
+            _log_http_exchange(url, headers, token_request)
         except ConfigException as e:
             raise ConfigEntryAuthFailed(str(e)) from e
         return token_request
@@ -615,9 +616,7 @@ class StellantisVehicles(StellantisOauth):
         token_request = await self.make_http_request(url, 'POST', headers)
         self.logger_filter.add_custom_value(token_request["access_token"])
         self.logger_filter.add_custom_value(token_request["refresh_token"])
-        _LOGGER.debug(url)
-        _LOGGER.debug(headers)
-        _LOGGER.debug(token_request)
+        _log_http_exchange(url, headers, token_request)
         new_config = {
             "access_token": token_request["access_token"],
             "refresh_token": token_request["refresh_token"],
@@ -646,9 +645,7 @@ class StellantisVehicles(StellantisOauth):
                     for vehicle in vehicles_request["_embedded"]["vehicles"]:
                         self.logger_filter.add_custom_value(vehicle["vin"])
                         self.logger_filter.add_custom_value(vehicle["id"])
-            _LOGGER.debug(url)
-            _LOGGER.debug(headers)
-            _LOGGER.debug(vehicles_request)
+            _log_http_exchange(url, headers, vehicles_request)
             if "_embedded" in vehicles_request:
                 if "vehicles" in vehicles_request["_embedded"]:
                     for vehicle in vehicles_request["_embedded"]["vehicles"]:
@@ -685,9 +682,7 @@ class StellantisVehicles(StellantisOauth):
         url = self.apply_query_params(CAR_API_GET_VEHICLE_STATUS_URL, CLIENT_ID_QUERY_PARAMS, vehicle)
         headers = self.apply_dict_params(CAR_API_HEADERS)
         vehicle_status_request = await self.make_http_request(url, 'GET', headers)
-        _LOGGER.debug(url)
-        _LOGGER.debug(headers)
-        _LOGGER.debug(vehicle_status_request)
+        _log_http_exchange(url, headers, vehicle_status_request)
         return vehicle_status_request
 
     @log_call
@@ -699,9 +694,7 @@ class StellantisVehicles(StellantisOauth):
         if page_token is not None:
             url += "&pageToken=" + page_token
         vehicle_trips_request = await self.make_http_request(url, 'GET', headers)
-        _LOGGER.debug(url)
-        _LOGGER.debug(headers)
-        _LOGGER.debug(vehicle_trips_request)
+        _log_http_exchange(url, headers, vehicle_trips_request)
         links = vehicle_trips_request.get("_links", {})
         last_href = links.get("last", {}).get("href")
         self_href = links.get("self", {}).get("href")
@@ -772,9 +765,7 @@ class StellantisVehicles(StellantisOauth):
             self.logger_filter.add_custom_value(token_request["access_token"])
         if "refresh_token" in token_request:
             self.logger_filter.add_custom_value(token_request["refresh_token"])
-        _LOGGER.debug(url)
-        _LOGGER.debug(headers)
-        _LOGGER.debug(token_request)
+        _log_http_exchange(url, headers, token_request)
         if not "access_token" in token_request:
             _LOGGER.warning("Refreshing mqtt access_token failed (no access_token in response)")
             return None
@@ -932,8 +923,7 @@ class StellantisVehicles(StellantisOauth):
                 "vin": vehicle["vin"],
                 "req_parameters": message
             })
-            _LOGGER.debug(topic)
-            _LOGGER.debug(data)
+            _LOGGER.debug("Publishing MQTT message to %s: %s", topic, data)
             message_info = self._mqtt.publish(topic, data, qos=MQTT_QOS, retain=False)
             if message_info.rc != mqtt.MQTT_ERR_SUCCESS:
                 _LOGGER.warning("Failed to send MQTT message: %s", mqtt.error_string(message_info.rc))
@@ -954,11 +944,11 @@ class StellantisVehicles(StellantisOauth):
     @log_call
     async def send_abrp_data(self, params):
         params["api_key"] = ABRP_API_KEY
-        _LOGGER.debug(params)
+        _LOGGER.debug("ABRP request params: %s", params)
         try:
             abrp_request = await self.make_http_request(ABRP_URL, "POST", None, params)
-            _LOGGER.debug(abrp_request)
+            _LOGGER.debug("ABRP response: %s", abrp_request)
             if "status" not in abrp_request or abrp_request["status"] != "ok":
-                _LOGGER.warning(abrp_request)
+                _LOGGER.warning("Unexpected ABRP response: %s", abrp_request)
         except Exception as e:
             _LOGGER.warning("Failed to send ABRP data: %s", e)

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -99,7 +99,7 @@ class MqttClientMod(mqtt.Client):
                 sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, 1460 - 4)
                 sock.settimeout(self._connect_timeout)
                 sock.bind((self._bind_address, self._bind_port))
-                _LOGGER.debug(f"Connecting to MQTT socket: {sa}")
+                _LOGGER.debug("Connecting to MQTT socket: %s", sa)
                 sock.connect(sa)
                 return sock
 
@@ -255,12 +255,12 @@ class StellantisBase:
                 return result
         except asyncio.TimeoutError as e:
             await self.close_session()
-            _LOGGER.warning(f"Error: {e}")
+            _LOGGER.warning("Request to %s timed out: %s", url, e)
             # Connection error
             raise CommunicationError("Request timeout") from e
         except aiohttp.client_exceptions.ClientError as e:
             await self.close_session()
-            _LOGGER.warning(f"Error: {e}")
+            _LOGGER.warning("Request to %s failed: %s", url, e)
             # Connection error
             raise CommunicationError(e) from e
         except (ConfigEntryAuthFailed, CommunicationError):
@@ -424,13 +424,13 @@ class StellantisOauth(StellantisBase):
         # Check if OTP object is already loaded, if not load it
         if self.otp is None:
             if not os.path.isfile(otp_file_path):
-                _LOGGER.error(f"Error: OTP file '{otp_file_path}' not found, please reauthenticate")
+                _LOGGER.error("OTP file '%s' not found, please reauthenticate", otp_file_path)
                 raise ConfigEntryAuthFailed("OTP file not found, please reauthenticate")
             self.otp = await self._hass.async_add_executor_job(load_otp, otp_file_path)
         # Get the OTP code using OTP object. It seems there is a rate limit of 6 requests per 24h
         otp_code = await self._hass.async_add_executor_job(self.otp.get_otp_code)
         if otp_code is None:
-            _LOGGER.error("Error: OTP code is empty, please reauthenticate")
+            _LOGGER.error("OTP code is empty, please reauthenticate")
             raise ConfigEntryAuthFailed("OTP code is empty, please reauthenticate")
         # Save updated OTP object to file
         await self._hass.async_add_executor_job(save_otp, self.otp, otp_file_path)
@@ -603,8 +603,7 @@ class StellantisVehicles(StellantisOauth):
         except RateLimitException:
             _LOGGER.warning("Rate limit exceeded, retry after 30 mins or check logs and restart integration")
             next_run = get_datetime() + timedelta(minutes=30)
-        _LOGGER.debug(f"Current time: {get_datetime()}")
-        _LOGGER.debug(f"Next refresh: {next_run}")
+        _LOGGER.debug("Next oauth token refresh scheduled for %s", next_run)
         next_job = HassJob(self.scheduled_oauth_token_refresh, f"{DOMAIN} refresh oauth token: {next_run}", cancel_on_shutdown=True)
         self._oauth_token_scheduled = async_track_point_in_time(self._hass, next_job, next_run)
 
@@ -749,8 +748,7 @@ class StellantisVehicles(StellantisOauth):
             await self.hass_notify("reconfigure_otp")
             _LOGGER.error("MQTT authentication error. To enable remote commands again please reconfigure the integration")
             return
-        _LOGGER.debug(f"Current time: {get_datetime()}")
-        _LOGGER.debug(f"Next refresh: {next_run}")
+        _LOGGER.debug("Next mqtt token refresh scheduled for %s", next_run)
         next_job = HassJob(self.scheduled_mqtt_token_refresh, f"{DOMAIN} refresh mqtt token: {next_run}", cancel_on_shutdown=True)
         self._mqtt_token_scheduled = async_track_point_in_time(self._hass, next_job, next_run)
 
@@ -817,25 +815,25 @@ class StellantisVehicles(StellantisOauth):
             )
             self._mqtt.loop_start() # Under the hood, this will call loop_forever in a thread, which means that the thread will terminate if we call disconnect()
         except Exception as e:
-            _LOGGER.warning(f"Error: {str(e)}")
+            _LOGGER.warning("Failed to connect to the MQTT broker: %s", e)
         return self._mqtt.is_connected()
 
     @log_call
     def _on_mqtt_connect(self, client, userdata, result_code, _):
-        _LOGGER.debug(f"Code: {result_code}")
+        _LOGGER.debug("MQTT connected (code %s)", result_code)
         try:
             topics = [MQTT_RESP_TOPIC + self.get_config("customer_id") + "/#"]
             for vehicle in self._vehicles:
                 topics.append(MQTT_EVENT_TOPIC + vehicle["vin"])
             for topic in topics:
                 client.subscribe(topic, qos=MQTT_QOS)
-                _LOGGER.debug(f"Topic: {topic}")
+                _LOGGER.debug("Subscribed to MQTT topic %s", topic)
         except Exception as e:
             _LOGGER.warning(f"Error: {str(e)}")
 
     @log_call
     def _on_mqtt_disconnect(self, client, userdata, result_code):
-        _LOGGER.debug(f"Code: {result_code} -> {mqtt.error_string(result_code)}")
+        _LOGGER.debug("MQTT disconnected (code %s: %s)", result_code, mqtt.error_string(result_code))
         if result_code == 11: # MQTT_ERR_AUTH
             # Runs on the paho network thread; wait=False keeps the reconnect loop
             # from blocking on the token refresh (network I/O, no timeout).
@@ -852,14 +850,14 @@ class StellantisVehicles(StellantisOauth):
                 # other callbacks)
                 self.do_async(self.connect_mqtt(), 300, wait=False)
             else:
-                _LOGGER.debug(f"Completed (QoS: {granted_qos})")
+                _LOGGER.debug("MQTT subscription completed (QoS: %s)", granted_qos)
         except Exception as e:
             _LOGGER.warning(f"Error: {str(e)}")
 
     @log_call
     def _on_mqtt_message(self, client, userdata, msg):
         try:
-            _LOGGER.debug(f"Message: {msg.topic} {msg.payload} {msg.qos}")
+            _LOGGER.debug("MQTT message on %s (qos %s): %s", msg.topic, msg.qos, msg.payload)
             data = json.loads(msg.payload)
             if msg.topic.startswith(MQTT_RESP_TOPIC):
                 if "vin" in data:
@@ -900,7 +898,7 @@ class StellantisVehicles(StellantisOauth):
                     if result_code in ["300", "500", "not_compatible", "failed"]:
                         self.do_async(self.hass_notify("command_error"), wait=False)
                     if result_code == "0":
-                        _LOGGER.debug(f"Fetch updates after code: {result_code}")
+                        _LOGGER.debug("Fetching updates after result code %s", result_code)
                         self.do_async(coordinator.async_refresh(), 10, wait=False)
 
                     self.do_async(coordinator.update_command_history(data["correlation_id"], result_code), wait=False)
@@ -938,7 +936,7 @@ class StellantisVehicles(StellantisOauth):
             _LOGGER.debug(data)
             message_info = self._mqtt.publish(topic, data, qos=MQTT_QOS, retain=False)
             if message_info.rc != mqtt.MQTT_ERR_SUCCESS:
-                _LOGGER.warning(f"Failed to send MQTT message: {mqtt.error_string(message_info.rc)}")
+                _LOGGER.warning("Failed to send MQTT message: %s", mqtt.error_string(message_info.rc))
                 action_id = None
             if store:
                 self._mqtt_last_request = [service, message]

--- a/custom_components/stellantis_vehicles/utils.py
+++ b/custom_components/stellantis_vehicles/utils.py
@@ -117,7 +117,7 @@ def rate_limit(limit: int, every: int):
             while calls and now - calls[0] >= every:
                 calls.popleft()
             if len(calls) >= limit:
-                _LOGGER.debug(f"Rate limit exceeded {func.__name__}: max {limit} per {every}s")
+                _LOGGER.debug("Rate limit exceeded %s: max %s per %ss", func.__name__, limit, every)
                 raise RateLimitException("rate_limit")
 
             calls.append(now)

--- a/custom_components/stellantis_vehicles/utils.py
+++ b/custom_components/stellantis_vehicles/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections import deque
 from datetime import UTC, datetime, timedelta
@@ -65,6 +66,39 @@ def sort_dict(items, ordered_keys=None):
         if key in items:
             result[key] = items[key]
     return result
+
+def log_call(func):
+    """Log entry and exit of a function at debug level.
+
+    Replaces the hand-written ``---------- START`` / ``---------- END`` markers.
+    Works on coroutine functions and plain functions alike (the latter for the
+    synchronous paho-mqtt callbacks). The exit line runs from a ``finally``
+    block, so it also covers the paths that return early or raise. Entry/exit
+    are logged under the decorated function's own module logger, so the lines
+    stay next to that module's other logging.
+    """
+    logger = logging.getLogger(func.__module__)
+    name = func.__name__
+
+    if asyncio.iscoroutinefunction(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            logger.debug("---------- START %s", name)
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                logger.debug("---------- END %s", name)
+    else:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            logger.debug("---------- START %s", name)
+            try:
+                return func(*args, **kwargs)
+            finally:
+                logger.debug("---------- END %s", name)
+
+    return wrapper
+
 
 def rate_limit(limit: int, every: int):
     """Reject calls once `limit` of them have run within the last `every` seconds.


### PR DESCRIPTION
## Summary

A housekeeping pass over the integration's logging. **No functional changes**: the same exceptions are raised and the same values returned; only what ends up in the log differs.

The `---------- START` / `---------- END` tracing has clearly been valuable: it makes a debug log readable and it is the fastest way to see which call a user's report died in. This PR keeps that behaviour exactly, with the same marker text and the same log lines, while taking the manual bookkeeping off your plate. Everything here builds on the pattern that was already there.

Split into four self-contained commits so each can be reviewed on its own (and the branch stays bisectable):

## Change

### 1. Move the `---------- START` / `---------- END` markers into a `log_call` decorator

Nearly every method opens and closes its own debug block by hand:

```python
_LOGGER.debug("---------- START get_access_token")
...
_LOGGER.debug("---------- END get_access_token")
```

That is just over 70 marker lines (62 in `stellantis.py` alone). Because the `END` line has to be repeated on every `return` and every `raise`, it is easy to miss one, and a few early-return and exception paths currently log a `START` with no matching `END`.

A small `log_call` decorator in `utils.py` produces the identical lines automatically. The `END` line runs from a `finally` block, so it now also covers the paths that return early or raise, meaning the traces that were previously the hardest to read are the ones that improve most. It resolves the logger from the decorated function's module, so every line stays under that module's own logger, and it handles both coroutine functions and the synchronous paho-mqtt callbacks (`_on_mqtt_connect` / `_on_mqtt_disconnect` / `_on_mqtt_subscribe` / `_on_mqtt_message`).

While removing the markers it also drops one now-empty `except Exception: raise` in `get_mqtt_access_token` that only existed to place an `END` line before re-raising.

**Benefit:** the same `---------- START` / `---------- END` output you rely on today, with ~70 fewer lines to maintain and no way to forget the closing marker on a new code path. `grep '---------- START'` keeps working unchanged.

### 2. Lazy `%`-formatting instead of f-strings in log calls

`_LOGGER.debug(f"...")` builds the string even when debug is off. Each logging call now uses `%` placeholders with args, so the work is skipped whenever the level is disabled, which for `debug` is almost always in production. This also clears ruff's `G004` (no f-strings in logging calls): 22 → 0 in `stellantis.py`, plus 7 in `__init__.py` and a couple in `utils.py`.

A few context-free `_LOGGER.warning(f"Error: {e}")` lines got a descriptive message while I was in there, and the redundant "current time" line was dropped from the two token-refresh schedule logs (the log record already carries a timestamp).

**Benefit:** no string-formatting cost on the common path where debug is disabled, `G004` clean, and the warnings that previously needed the source open to interpret now read on their own.

### 3. `_log_http_exchange` helper + labelled dumps

The pattern

```python
_LOGGER.debug(url)
_LOGGER.debug(headers)
_LOGGER.debug(response)
```

appears at ~9 call sites, producing three unlabelled lines that are hard to correlate when requests overlap. A single `_log_http_exchange(url, headers, response)` helper (guarded by `isEnabledFor(DEBUG)`) replaces them with one labelled record. The multi-line error dump in `make_http_request` is consolidated the same way, and the remaining bare `_LOGGER.debug(<var>)` calls got descriptive prefixes.

**Benefit:** one correlatable line per request instead of 3–6 loose ones (still readable when the coordinator and MQTT log concurrently), and the guard skips the formatting entirely when debug is off.

### 4. `_LOGGER.exception()` in the catch-all handlers

The broad `except Exception` handlers fall into two kinds:

- In `make_http_request`, the MQTT callbacks (`_on_mqtt_connect` / `_on_mqtt_subscribe` / `_on_mqtt_message`), and `send_mqtt_message`, the block did a contextless `_LOGGER.warning(f"Error: {e}")` and dropped the traceback; an exception there usually means a bug in that block, so the traceback is what you actually need. These now use `_LOGGER.exception(...)` (re-raise behaviour unchanged).
- Handlers that catch an *expected* external failure and carry on (`connect_mqtt` for a broker that is unreachable, `send_abrp_data` for a best-effort telemetry push) keep a one-line `_LOGGER.warning("...: %s", e)` without a traceback, since there is nothing to debug.

**Benefit:** unexpected failures now arrive with a full traceback and a location (the old `Error: {e}` was often just `'correlation_id'` with no hint where), logged at `ERROR` rather than `WARNING`, while the routine "broker was down" case stays a quiet one-liner.

## Behaviour

- `SensitiveDataFilter` still masks everything it did before: it masks `record.args` element-wise, so `%`-style logging is covered exactly the way the previous bare-object logging was.
- One observable difference: `scheduled_mqtt_token_refresh` now emits its entry/exit debug lines even when remote commands are disabled (its early `return` is now inside the decorated function). Two extra debug lines when debug is on, nothing else.
- Logging only. No change to control flow, retries, exception types, or return values.

## Rebase note

Touches `__init__.py`, `base.py`, `config_flow.py`, `stellantis.py`, `utils.py` (+124 / -150). Overlaps with any branch that edits logging or exception handling in `stellantis.py`; expect context-only conflicts on the marker/f-string lines.

## Manual verification and testing on my running instance

- [x] Reload the integration, set `custom_components.stellantis_vehicles` to `debug`, confirm `START` / `END` and `HTTP exchange` lines appear.
- [x] Token / VIN masking still works with `anonymize_logs` enabled.
- [x] Reauth flow completes.
- [x] One coordinator update cycle runs cleanly.
- [x] MQTT connects and vehicle events are still processed.
