### PR TITLE
Add mileage and days before maintenance sensors

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -75,6 +75,13 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
 
         try:
             new_data = await self._stellantis.get_vehicle_status(self._vehicle)
+            if new_data:
+                maintenance = await self._stellantis.get_vehicle_maintenance(self._vehicle)
+                new_data["maintenance"] = {
+                    "mileageBeforeMaintenance": maintenance.get("mileageBeforeMaintenance"),
+                    "daysBeforeMaintenance": maintenance.get("daysBeforeMaintenance"),
+                    "updatedAt": maintenance.get("updatedAt")
+                }
         except ConfigEntryAuthFailed:
             _LOGGER.debug("---------- END _async_update_data")
             raise

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from homeassistant.const import ( UnitOfTemperature, UnitOfLength, PERCENTAGE, UnitOfEnergy, UnitOfSpeed, UnitOfVolume, EntityCategory )
+from homeassistant.const import ( UnitOfTemperature, UnitOfLength, UnitOfTime, PERCENTAGE, UnitOfEnergy, UnitOfSpeed, UnitOfVolume, EntityCategory )
 from homeassistant.components.sensor.const import ( SensorDeviceClass, SensorStateClass )
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
@@ -40,6 +40,7 @@ CAR_API_BASE_URL = API_BASE_URL + "/connectedcar/v4/user"
 CAR_API_VEHICLES_URL = CAR_API_BASE_URL + "/vehicles"
 CAR_API_GET_VEHICLE_STATUS_URL = CAR_API_VEHICLES_URL + "/{#vehicle_id#}/status"
 CAR_API_GET_VEHICLE_TRIPS_URL = CAR_API_VEHICLES_URL + "/{#vehicle_id#}/trips"
+CAR_API_GET_VEHICLE_MAINTENANCE_URL = CAR_API_VEHICLES_URL + "/{#vehicle_id#}/maintenance"
 
 MQTT_SERVER = "mwa.mpsa.com"
 MQTT_PORT = 8885
@@ -311,6 +312,22 @@ SENSORS_DEFAULT = {
         "icon": "mdi:steering",
         "value_map" : ["drivingBehavior", "mode"],
         "updated_at_map" : ["drivingBehavior", "createdAt"]
+    },
+    "mileage_before_maintenance" : {
+        "icon" : "mdi:car-wrench",
+        "unit_of_measurement" : UnitOfLength.KILOMETERS,
+        "device_class": SensorDeviceClass.DISTANCE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "value_map" : ["maintenance", "mileageBeforeMaintenance"],
+        "updated_at_map" : ["maintenance", "updatedAt"]
+    },
+    "days_before_maintenance" : {
+        "icon" : "mdi:calendar-clock",
+        "unit_of_measurement" : UnitOfTime.DAYS,
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "value_map" : ["maintenance", "daysBeforeMaintenance"],
+        "updated_at_map" : ["maintenance", "updatedAt"]
     }
 }
 

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -26,7 +26,7 @@ from homeassistant.util.ssl import client_context
 
 from .base import StellantisVehicleCoordinator
 from .otp.otp import Otp, save_otp, load_otp, ConfigException
-from .utils import ( get_datetime, rate_limit, SensitiveDataFilter, replace_string_placeholders )
+from .utils import ( get_datetime, rate_limit, SensitiveDataFilter, replace_string_placeholders, log_call )
 from .exceptions import ( CommunicationError, RateLimitException )
 
 from .const import (
@@ -64,7 +64,8 @@ from .const import (
     OTP_FILENAME,
     ABRP_URL,
     ABRP_API_KEY,
-    TRANSLATION_PLACEHOLDERS
+    TRANSLATION_PLACEHOLDERS,
+    CAR_API_GET_VEHICLE_MAINTENANCE_URL
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -736,6 +737,15 @@ class StellantisVehicles(StellantisOauth):
                 return await self.get_vehicle_last_trip(vehicle, next_page_token)
         _LOGGER.debug("---------- END get_vehicle_last_trip")
         return vehicle_trips_request
+
+    @log_call
+    async def get_vehicle_maintenance(self, vehicle):
+        """ Fetch upcoming maintenance data (mileage/days remaining) for the vehicle. """
+        url = self.apply_query_params(CAR_API_GET_VEHICLE_MAINTENANCE_URL, CLIENT_ID_QUERY_PARAMS, vehicle)
+        headers = self.apply_dict_params(CAR_API_HEADERS)
+        vehicle_maintenance_request = await self.make_http_request(url, 'GET', headers)
+        _log_http_exchange(url, headers, vehicle_maintenance_request)
+        return vehicle_maintenance_request
 
 #     async def get_vehicle_trips(self, page_token=False):
 #         _LOGGER.debug("---------- START get_vehicle_trips")

--- a/custom_components/stellantis_vehicles/translations/de.json
+++ b/custom_components/stellantis_vehicles/translations/de.json
@@ -106,6 +106,12 @@
       "autonomy": {
         "name": "Reichweite"
       },
+      "mileage_before_maintenance": {
+        "name": "Kilometer bis zur nächsten Wartung"
+      },
+      "days_before_maintenance": {
+        "name": "Tage bis zur nächsten Wartung"
+      },
       "battery": {
         "name": "Batterie"
       },

--- a/custom_components/stellantis_vehicles/translations/en.json
+++ b/custom_components/stellantis_vehicles/translations/en.json
@@ -107,6 +107,12 @@
       "autonomy": {
         "name": "Autonomy"
       },
+      "mileage_before_maintenance": {
+        "name": "Mileage before maintenance"
+      },
+      "days_before_maintenance": {
+        "name": "Days before maintenance"
+      },
       "battery": {
         "name": "Battery"
       },

--- a/custom_components/stellantis_vehicles/translations/fr.json
+++ b/custom_components/stellantis_vehicles/translations/fr.json
@@ -107,6 +107,12 @@
       "autonomy": {
         "name": "Autonomie batterie"
       },
+      "mileage_before_maintenance": {
+        "name": "Kilométrage avant entretien"
+      },
+      "days_before_maintenance": {
+        "name": "Jours avant entretien"
+      },
       "battery": {
         "name": "Niveau batterie"
       },

--- a/custom_components/stellantis_vehicles/translations/it.json
+++ b/custom_components/stellantis_vehicles/translations/it.json
@@ -106,6 +106,12 @@
       "autonomy": {
         "name": "Autonomia"
       },
+      "mileage_before_maintenance": {
+        "name": "Chilometri al prossimo tagliando"
+      },
+      "days_before_maintenance": {
+        "name": "Giorni al prossimo tagliando"
+      },
       "battery": {
         "name": "Batteria"
       },


### PR DESCRIPTION
## Summary

Adds two new sensors backed by the `/maintenance` vehicle endpoint: mileage remaining and days remaining until the next scheduled maintenance.

## Change

### 1. `get_vehicle_maintenance` API call

New method on `StellantisVehicles`, following the same shape as the existing `get_vehicle_status` / `get_vehicle_last_trip` calls (`CAR_API_GET_VEHICLE_MAINTENANCE_URL` request, `@log_call` decorator, `_log_http_exchange` for the debug dump, docstring). Unlike the remote-command endpoints it does not need the MQTT-connect guard, since it is a plain REST `GET`. **`@log_call` / `_log_http_exchange` come from #583 (see dependency note above), not from this PR.** The endpoint returns a small payload:

```json
{
  "createdAt": "...",
  "updatedAt": "...",
  "mileageBeforeMaintenance": 540.0,
  "daysBeforeMaintenance": 169
}
```

### 2. Fetch and merge into the coordinator's vehicle data

`_async_update_data` fetches maintenance data right after the vehicle status and stores the three fields of interest under a new `new_data["maintenance"]` node:

```python
new_data["maintenance"] = {
    "mileageBeforeMaintenance": maintenance.get("mileageBeforeMaintenance"),
    "daysBeforeMaintenance": maintenance.get("daysBeforeMaintenance"),
    "updatedAt": maintenance.get("updatedAt")
}
```

The fetch and merge only run when `new_data` already has content, so an empty/404 vehicle-status response is still detected as empty by the `if not new_data:` check further down (adding an unconditional `"maintenance"` key would otherwise make an empty dict truthy and defeat that check).

### 3. Two new `SENSORS_DEFAULT` entries

`mileage_before_maintenance` (km, `SensorDeviceClass.DISTANCE`) and `days_before_maintenance` (days, `UnitOfTime.DAYS`) are added to the existing config-driven sensor table, both reading from `["maintenance", ...]` and using `["maintenance", "updatedAt"]` for their `updated_at_map`. No new sensor code is needed — `sensor.py` already turns any `SENSORS_DEFAULT` entry with `value_map` + `updated_at_map` into an entity.

### 4. Translations

Added `mileage_before_maintenance` / `days_before_maintenance` entity names to `en`, `de`, `fr`, `it`.

## Behaviour

- New sensors only; no existing sensor, service, or config-flow behaviour changes.
- If the maintenance endpoint ever omits a field, the corresponding sensor value is `None` (existing `get_value_from_map` handling), not an exception.

## Manual verification and testing on my running instance:
- [x] Reload the integration and confirm `sensor.<vehicle>_mileage_before_maintenance` and `sensor.<vehicle>_days_before_maintenance` appear with the expected values.
- [x] Confirm no other sensors regressed (coordinator update still populates `self._data` as before).
- [x] Confirm the empty-response handling (`if not new_data:`) still triggers correctly on a simulated empty/404 response.
