### PR TITLE
Extend credential masking in logs as an extra precaution

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -335,6 +335,8 @@ class StellantisOauth(StellantisBase):
 
     @log_call
     async def get_oauth_code(self, email, password, code_url=None):
+        self.logger_filter.add_custom_value(email)
+        self.logger_filter.add_custom_value(password)
         oauth_code_request = await self.make_http_request(code_url or OAUTH_CODE_URL, 'POST', None, None, {"url": self.get_oauth_url(), "email": email, "password": password}, None, 300)
         if "code" in oauth_code_request:
             self.logger_filter.add_custom_value(oauth_code_request["code"])


### PR DESCRIPTION
## Summary

`SensitiveDataFilter` (in `utils.py`) already does a great job masking `access_token`, `refresh_token`, `oauth_code` and `customer_id` when `anonymize_logs` is enabled. This PR extends that same coverage to a few more values, purely as a defensive measure so that anonymized logs stay anonymized even on less common code paths:

- `client_id`, `client_secret` and the derived `basic_token` — these already land in `self._config` via `save_config()`, so they fit naturally alongside the keys the filter already handles.
- `email` and `password` — these are passed as arguments into `get_oauth_code()` and end up in the request body. If a request fails, `make_http_request()` logs the body at debug level, so it seems safer to have these masked up front just in case a login ever errors out.

## Change

~~### 1. Add `client_id`, `client_secret`, `basic_token` to `masked_entry_keys`~~

~~These are stored in `self._config` exactly like the already-masked `customer_id`, so adding them to the existing key list in `SensitiveDataFilter.__init__` is all that's needed — no new mechanism.~~

### 2. Register `email` / `password` as custom masked values in `get_oauth_code`

Unlike the keys above, `email`/`password` are never stored in `self._config` — they only exist as arguments to `get_oauth_code()`. Registering them via `self.logger_filter.add_custom_value(...)` at the top of the method means they're already covered before the request runs, so anonymized logs stay clean even if the request fails.

## Behaviour

- Only affects what gets written to the log when `anonymize_logs` is enabled — no change to control flow, requests made, or values returned.
- The new values follow the same masking rules as the existing ones (first 5 characters kept, rest replaced with `###`; short values fully replaced).

## Scope / non-goals

- Logging only, limited to `SensitiveDataFilter` and `get_oauth_code`.
- No changes to `config_flow.py`: `email`/`password` aren't logged there today (no `_LOGGER` calls reference `user_input`), so there's nothing to add on that path right now.
