### PR TITLE
Move async_remove_entry filesystem cleanup off the event loop

### DIFF
--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -138,33 +138,39 @@ async def async_remove_entry(hass: HomeAssistant, config: ConfigEntry) -> None:
         for _entry in hass.config_entries.async_entries(DOMAIN):
             hass.async_create_task(hass.config_entries.async_remove(_entry.entry_id))
 
-        # Gennerate path to storage folder and OTP file
+        # Generate path to storage folder and OTP file
         hass_config_path = hass.config.path()
         storage_path = os.path.join(hass_config_path, ".storage", DOMAIN)
         otp_file_path = os.path.join(storage_path, OTP_FILENAME)
         otp_file_path = otp_file_path.replace("{#customer_id#}", config.unique_id)
-
-        # Remove OTP file if it exists
-        if os.path.isfile(otp_file_path):
-            _LOGGER.debug("Deleting OTP file: %s", otp_file_path)
-            os.remove(otp_file_path)
-
-        # Remove storage folder if empty
-        if os.path.exists(storage_path) and os.path.isdir(storage_path) and not os.listdir(storage_path):
-            _LOGGER.debug("Deleting empty Stellantis storage folder: %s", storage_path)
-            shutil.rmtree(storage_path)
-
-        # Remove Stellantis image folder of this entry
         entry_image_path = os.path.join(hass_config_path, "www", DOMAIN, config.unique_id)
-        if os.path.exists(entry_image_path) and os.path.isdir(entry_image_path):
-            _LOGGER.debug("Deleting Stellantis entry image folder: %s", entry_image_path)
-            shutil.rmtree(entry_image_path)
-
-        # Remove Stellantis image folder if empty
         image_path = os.path.join(hass_config_path, "www", DOMAIN)
-        if os.path.exists(image_path) and os.path.isdir(image_path) and not os.listdir(image_path):
-            _LOGGER.debug("Deleting Stellantis image folder: %s", image_path)
-            shutil.rmtree(image_path)
+
+        def cleanup_files():
+            # Run the blocking filesystem work on an executor thread so it never
+            # stalls the event loop - matches the async_migrate_entry steps.
+
+            # Remove OTP file if it exists
+            if os.path.isfile(otp_file_path):
+                _LOGGER.debug("Deleting OTP file: %s", otp_file_path)
+                os.remove(otp_file_path)
+
+            # Remove storage folder if empty
+            if os.path.exists(storage_path) and os.path.isdir(storage_path) and not os.listdir(storage_path):
+                _LOGGER.debug("Deleting empty Stellantis storage folder: %s", storage_path)
+                shutil.rmtree(storage_path)
+
+            # Remove Stellantis image folder of this entry
+            if os.path.exists(entry_image_path) and os.path.isdir(entry_image_path):
+                _LOGGER.debug("Deleting Stellantis entry image folder: %s", entry_image_path)
+                shutil.rmtree(entry_image_path)
+
+            # Remove Stellantis image folder if empty
+            if os.path.exists(image_path) and os.path.isdir(image_path) and not os.listdir(image_path):
+                _LOGGER.debug("Deleting Stellantis image folder: %s", image_path)
+                shutil.rmtree(image_path)
+
+        await hass.async_add_executor_job(cleanup_files)
 
 
 async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):

--- a/custom_components/stellantis_vehicles/__init__.py
+++ b/custom_components/stellantis_vehicles/__init__.py
@@ -184,10 +184,15 @@ async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):
         if config.unique_id != new_unique_id:
             _LOGGER.debug("Migrating unique_id from %s to %s", config.unique_id, new_unique_id)
             hass.config_entries.async_update_entry(config, unique_id=new_unique_id)
-        # Migrate to new file structure - Generate path to storage folder and move OTP file
+        # Migrate to new file structure - generate path to storage folder and move OTP file
         hass_config_path = hass.config.path()
         old_otp_file_path = os.path.join(hass_config_path, ".storage/stellantis_vehicles_otp.pickle")
-        if os.path.isfile(old_otp_file_path):
+
+        def migrate_otp_file():
+            # Run the blocking filesystem work on an executor thread so it never
+            # stalls the event loop - matches the later migration steps.
+            if not os.path.isfile(old_otp_file_path):
+                return
             new_storage_path = os.path.join(hass_config_path, ".storage", DOMAIN)
             new_otp_file_path = os.path.join(new_storage_path, OTP_FILENAME)
             new_otp_file_path = new_otp_file_path.replace("{#customer_id#}", new_unique_id)
@@ -198,6 +203,8 @@ async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):
                 os.rename(old_otp_file_path, new_otp_file_path)
             else:
                 os.remove(old_otp_file_path)
+
+        await hass.async_add_executor_job(migrate_otp_file)
         # Update config entry object
         hass.config_entries.async_update_entry(config, version=target_version, minor_version=target_minor_version)
         _LOGGER.debug("Migration to configuration version %s.%s successful", config.version, config.minor_version)
@@ -208,9 +215,15 @@ async def async_migrate_entry(hass: HomeAssistant, config: ConfigEntry):
         _LOGGER.debug("Migrating configuration from version %s.%s", config.version, config.minor_version)
         public_path = hass.config.path("www")
         old_image_path = f"{public_path}/stellantis-vehicles"
-        if os.path.isdir(old_image_path):
-            _LOGGER.debug("Deleting Stellantis old image folder: %s", old_image_path)
-            shutil.rmtree(old_image_path)
+
+        def remove_old_image_folder():
+            # Run the blocking filesystem work on an executor thread so it never
+            # stalls the event loop - matches the later migration steps.
+            if os.path.isdir(old_image_path):
+                _LOGGER.debug("Deleting Stellantis old image folder: %s", old_image_path)
+                shutil.rmtree(old_image_path)
+
+        await hass.async_add_executor_job(remove_old_image_folder)
         hass.config_entries.async_update_entry(config, version=target_version, minor_version=target_minor_version)
         _LOGGER.debug("Migration to configuration version %s.%s successful", config.version, config.minor_version)
 


### PR DESCRIPTION
`async_remove_entry` runs its `os` and `shutil.rmtree` cleanup synchronously inside an `async def`, so it blocks the event loop. On a slow or network-mounted `.storage`, or with a large `www/stellantis_vehicles/<id>` image folder, that stalls Home Assistant long enough for it to log a blocking-call warning.

The fix follows the pattern the newer `async_migrate_entry` steps already use: move the blocking calls into a nested helper and run it via `hass.async_add_executor_job`. Same paths, conditions and order, only the thread changes. The two oldest migration steps (`1.1` to `1.2`, `1.2` to `1.3`) had the same issue and get the same treatment. One file, `custom_components/stellantis_vehicles/__init__.py`.