### PR TITLE
Return None instead of raising on an unparseable stored time value

### DIFF
--- a/custom_components/stellantis_vehicles/utils.py
+++ b/custom_components/stellantis_vehicles/utils.py
@@ -37,7 +37,11 @@ def time_from_pt_string(pt_string):
     return datetime.strptime(pt_string, regex).time()
 
 def time_from_string(string):
-    return datetime.strptime(string, "%H:%M:%S").time()
+    try:
+        return datetime.strptime(string, "%H:%M:%S").time()
+    except (AttributeError, TypeError, ValueError) as e:
+        _LOGGER.warning("Could not parse time '%s': %s", string, e)
+        return None
 
 def date_from_pt_string(pt_string, start_date=None):
     if not start_date:


### PR DESCRIPTION
## Problem

`time_from_string()` had no error handling, unlike its siblings `time_from_pt_string()` and `date_from_pt_string()`. It runs on the restored recorder state in `StellantisRestoreEntity.async_added_to_hass()` (`time_*` branch), so a corrupt or old-format value makes `strptime` raise `ValueError`, and the entity fails to load.

## Change

`time_from_string()`: wrap the `strptime` call in `try` / `except (AttributeError, TypeError, ValueError)`, log a warning, and return `None`. Same pattern as `time_from_pt_string()`. The caller stores `None`, and `StellantisBaseTime.native_value` already handles that, so the entity restores in the unknown state instead of not loading.
