### PR TITLE
I/O cleanup in stellantis.py

### DIFF
--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -3,7 +3,7 @@ import aiohttp
 import base64
 from PIL import Image, ImageOps
 import os
-from urllib.request import urlopen
+from io import BytesIO
 from copy import deepcopy
 import paho.mqtt.client as mqtt
 import json
@@ -18,6 +18,7 @@ from homeassistant.helpers import translation
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.components import persistent_notification
 from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.ssl import client_context
 # If the Stellantis MQTT broker ever presents a certificate that fails
 # validation, import client_context_no_verify here as well and use it in
@@ -532,10 +533,17 @@ class StellantisVehicles(StellantisOauth):
         image_url = image_path.replace(public_path, "/local")
         if os.path.isfile(image_path):
             return image_url
-        image = await self._hass.async_add_executor_job(urlopen, url)
-        with Image.open(image) as im:
-            im = ImageOps.pad(im, (400, 400))
-        await self._hass.async_add_executor_job(im.save, image_path)
+        session = async_get_clientsession(self._hass)
+        async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+            resp.raise_for_status()
+            image_data = await resp.read()
+
+        def _resize_and_save() -> None:
+            with Image.open(BytesIO(image_data)) as im:
+                im = ImageOps.pad(im, (400, 400))
+                im.save(image_path)
+
+        await self._hass.async_add_executor_job(_resize_and_save)
         return image_url
 
     def reset_scheduled_tokens(self):

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -465,7 +465,6 @@ class StellantisVehicles(StellantisOauth):
             new_data[config] = None
         new_data[config] = value
         self._hass.config_entries.async_update_entry(self._entry, data=new_data)
-        self._hass.config_entries._async_schedule_save()
 
     def get_stored_config(self, config):
         if config in self._entry.data:


### PR DESCRIPTION
Two tiny, independent robustness fixes in `stellantis.py`, one commit each.

## Commit 1: Drop redundant private `config_entries` save

`update_stored_config` called `self._hass.config_entries._async_schedule_save()` right after `async_update_entry(...)`. `async_update_entry` already schedules that save itself, so the extra call was redundant and poked at a private HA API. Removed the line; the config entry is still persisted through the public path.

## Commit 2: Download the vehicle picture via the HA client session with a timeout

`resize_and_save_picture` fetched the picture with `urlopen` and no timeout (default socket timeout is `None`), so a stalled CDN could hang the executor thread forever. The `ImageOps.pad(...)` decode also ran on the event loop.

- Fetch with `async_get_clientsession(...)` and `aiohttp.ClientTimeout(total=30)`, reading the bytes async.
- `resp.raise_for_status()` keeps the old "raise on HTTP error" behaviour; the caller in `get_vehicles` already handles that.
- Move the whole Pillow step into one `async_add_executor_job`, so nothing decodes on the event loop.
- Swap `from urllib.request import urlopen` for `from io import BytesIO` plus the `async_get_clientsession` import.

No config, entity, or translation changes. Both commits touch only the import block, `update_stored_config`, and `resize_and_save_picture`.

## Manual check

- [x] Reload the integration and confirm vehicle pictures still download to `www/stellantis_vehicles/<customer_id>/<vin>.png` (delete one to force a re-download).
- [x] Block the picture host and confirm setup no longer hangs, with a warning after ~30 s instead.
- [x] Toggle a stored-config value (e.g. remote commands) and restart HA to confirm it persisted.
