### PR TITLE
Add exponential backoff to the MQTT token refresh retry

### DIFF
--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -131,6 +131,11 @@ UPDATE_INTERVAL = 60 # seconds
 # re-fetched to check whether the vehicle was unpaired.
 EMPTY_STATUS_LIMIT = 3
 
+# Backoff schedule (seconds) for the MQTT token refresh after a transient
+# Stellantis backend failure. Capped at the last step so a prolonged outage is
+# retried every ~15 min instead of once a minute.
+MQTT_TOKEN_RETRY_BACKOFF = (60, 120, 300, 600, 900)
+
 VEHICLE_TYPE_ELECTRIC = "Electric"
 VEHICLE_TYPE_HYBRID = "Hybrid"
 VEHICLE_TYPE_THERMIC = "Thermic"

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -66,7 +66,8 @@ from .const import (
     ABRP_URL,
     ABRP_API_KEY,
     TRANSLATION_PLACEHOLDERS,
-    CAR_API_GET_VEHICLE_MAINTENANCE_URL
+    CAR_API_GET_VEHICLE_MAINTENANCE_URL,
+    MQTT_TOKEN_RETRY_BACKOFF
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -454,6 +455,7 @@ class StellantisVehicles(StellantisOauth):
 
         self._oauth_token_scheduled = None
         self._mqtt_token_scheduled = None
+        self._mqtt_token_retry = 0
 
     def set_entry(self, entry):
         self._entry = entry
@@ -750,13 +752,24 @@ class StellantisVehicles(StellantisOauth):
             self.reset_scheduled_mqtt_token()
             if force or get_datetime() > get_next_run():
                 await self.refresh_mqtt_token_request()
+            self._mqtt_token_retry = 0
             next_run = get_next_run()
-        except CommunicationError:
-            next_run = get_datetime() + timedelta(minutes=1)
+        except CommunicationError as err:
+            self._mqtt_token_retry += 1
+            idx = min(self._mqtt_token_retry - 1, len(MQTT_TOKEN_RETRY_BACKOFF) - 1)
+            delay = MQTT_TOKEN_RETRY_BACKOFF[idx]
+            delay += random.uniform(0, delay * 0.1)
+            next_run = get_datetime() + timedelta(seconds=delay)
+            _LOGGER.warning(
+                "MQTT token refresh failed (attempt %s), next retry at %s: %s",
+                self._mqtt_token_retry, next_run, err,
+            )
         except RateLimitException:
+            self._mqtt_token_retry = 0
             _LOGGER.warning("Rate limit exceeded, retry after 1 day or check logs and restart integration")
             next_run = get_datetime() + timedelta(days=1)
         except ConfigException:
+            self._mqtt_token_retry = 0
             self.disable_remote_commands()
             await self.hass_notify("reconfigure_otp")
             _LOGGER.error("MQTT authentication error. To enable remote commands again please reconfigure the integration")


### PR DESCRIPTION
## Summary

`scheduled_mqtt_token_refresh` reschedules itself a flat 60 seconds later on every `CommunicationError`, with no log line in that branch. When the Stellantis token backend has a sustained outage (an intermittent `401 Unauthorized - Cannot pass the security checks ...`, or `400 server_error: "Could not read token in CTS: Failed to read Token"`), the integration retries the token endpoint once a minute for as long as the outage lasts, and none of it is visible unless debug logging is on. Issue #597 shows roughly 18 such retries in 18 minutes.

This changes the retry to a capped backoff schedule with jitter, resets the counter on success, and logs each failed attempt at WARNING so the retry loop is visible without debug logging. The regular (non-error) refresh cadence, still anchored to the token expiry, is unchanged.

## Change

`const.py`:

- New `MQTT_TOKEN_RETRY_BACKOFF = (60, 120, 300, 600, 900)`: the retry delay in seconds after the 1st, 2nd, ... consecutive failure, capped at the last step (so a prolonged outage is retried every ~15 minutes instead of every minute).

`stellantis.py`, `scheduled_mqtt_token_refresh`:

- New instance counter `self._mqtt_token_retry` (init `0`).
- Success path (a completed `refresh_mqtt_token_request()`, or a call made while no refresh was due): reset the counter to `0`, then schedule from `get_next_run()` as before.
- `except CommunicationError`: increment the counter, take `MQTT_TOKEN_RETRY_BACKOFF[min(retry - 1, len - 1)]`, add up to 10% jitter (`random.uniform(0, delay * 0.1)`, so several config entries do not retry in lockstep), schedule that many seconds out, and log `MQTT token refresh failed (attempt N), next retry at ...` at WARNING.
- `except RateLimitException` and `except ConfigException`: unchanged behaviour, plus a counter reset to `0`.

## Behaviour

| | Before | After |
|---|---|---|
| Single transient failure | retried after 60 s, no log line (debug-only at the end) | retried after ~60 s, one WARNING with the attempt number and reason |
| Sustained token-backend outage | retried every 60 s for the whole outage | retried after ~60 s, 2 m, 5 m, 10 m, then every 15 m |
| Recovery | n/a (counter did not exist) | next success resets the counter; the following failure starts again at 60 s |
| Regular refresh (no error) | scheduled at token expiry minus 3 min (~12 min out) | unchanged |
| Rate limit / bad OTP config | 1 day / disable remote commands | unchanged (counter also reset) |

