### PR TITLE
Retry once after a transient 401 before failing

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -86,7 +86,9 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             raise
         except Exception as err:
             _LOGGER.debug("Error communicating with Stellantis API: %s", err)
-            raise UpdateFailed("Error communicating with Stellantis API") from err
+            raise UpdateFailed(
+                "Error communicating with Stellantis API, enable debug logging for details"
+            ) from err
 
         if not new_data:
             # Keep the last known data instead of blanking every entity on a

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -212,7 +212,7 @@ class StellantisBase:
         return self.replace_placeholders(f"{url}?{query_params}", vehicle)
 
     @log_call
-    async def make_http_request(self, url, method='GET', headers=None, params=None, json_data=None, data=None, timeout=60):
+    async def make_http_request(self, url, method='GET', headers=None, params=None, json_data=None, data=None, timeout=60, _retried=False):
         """Perform an HTTP request and return the decoded JSON response."""
         self.start_session()
         try:
@@ -255,8 +255,24 @@ class StellantisBase:
                         # Token expiration
                         raise ConfigEntryAuthFailed(error)
                     if str(resp.status) == "401":
-                        # Oauth token seem expired, refresh request blocked by server/connection error
-                        raise CommunicationError(error)
+                        # The OAuth access token was rejected. This is usually a
+                        # short-lived blip right after a token rotation, so
+                        # refresh the token once and retry the same request
+                        # before surfacing an error.
+                        if not _retried and OAUTH_TOKEN_URL not in url:
+                            _LOGGER.debug("401 received, refreshing the OAuth token and retrying once")
+                            try:
+                                await self.refresh_oauth_token_request()
+                            except (CommunicationError, RateLimitException) as refresh_err:
+                                # ConfigEntryAuthFailed (dead refresh token) is left
+                                # to propagate so Home Assistant starts reauth.
+                                _LOGGER.debug("Token refresh before retry failed: %s", refresh_err)
+                            else:
+                                new_token = (self.get_config("oauth") or {}).get("access_token")
+                                if headers and "Authorization" in headers and new_token:
+                                    headers = {**headers, "Authorization": f"Bearer {new_token}"}
+                                return await self.make_http_request(url, method, headers, params, json_data, data, timeout, _retried=True)
+                        raise CommunicationError("Stellantis rejected the access token (HTTP 401)")
                     if str(resp.status).startswith("50"):
                         # Internal error
                         raise CommunicationError(error)

--- a/custom_components/stellantis_vehicles/stellantis.py
+++ b/custom_components/stellantis_vehicles/stellantis.py
@@ -238,22 +238,22 @@ class StellantisBase:
 
                     if str(resp.status) == "404" and str(result.get("code")) == "40400":
                         # Not Found: We didn't find the status for this vehicle. - 40400
-                        _LOGGER.warning(error)
+                        _LOGGER.warning(error or "Vehicle status not found (HTTP 404)")
                         return {}
                     if str(resp.status).startswith("500") and str(result.get("code")) == "50038":
                         # CVS error/user-vins - 50038: a transient Stellantis backend
                         # failure while resolving the account's VIN list. Treat it like
                         # an empty status so the coordinator keeps the last known data
                         # for a few cycles instead of dropping every entity.
-                        _LOGGER.warning(error)
+                        _LOGGER.warning(error or "Transient CVS user-vins error (HTTP 500)")
                         return {}
                     if str(resp.status) == "500" and str(result.get("code")) == "50000":
                         # Connection module replaced (https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/issues/388)
                         # https://github.com/andreadegiovine/homeassistant-stellantis-vehicles/pull/475
-                        raise CommunicationError(error)
+                        raise CommunicationError(error or "Stellantis connection module error (HTTP 500)")
                     if str(resp.status) == "400" and result.get("error") == "invalid_grant":
                         # Token expiration
-                        raise ConfigEntryAuthFailed(error)
+                        raise ConfigEntryAuthFailed(error or "Stellantis rejected the request (invalid_grant)")
                     if str(resp.status) == "401":
                         # The OAuth access token was rejected. This is usually a
                         # short-lived blip right after a token rotation, so
@@ -275,7 +275,7 @@ class StellantisBase:
                         raise CommunicationError("Stellantis rejected the access token (HTTP 401)")
                     if str(resp.status).startswith("50"):
                         # Internal error
-                        raise CommunicationError(error)
+                        raise CommunicationError(error or f"Stellantis internal server error (HTTP {resp.status})")
                     # Any other non-2xx response we don't have a specific case for
                     raise CommunicationError(error or f"Unexpected HTTP status {resp.status}")
 


### PR DESCRIPTION
A transient `401` right after an OAuth token rotation surfaces as `UpdateFailed("Error communicating with Stellantis API")`, even though the next poll usually succeeds on its own.

**What this PR change**

- `make_http_request(..., _retried=False)`: on a first-attempt `401` for a non-token-endpoint URL, call `refresh_oauth_token_request()` once, swap the fresh bearer into the `Authorization` header and retry. If it still fails, raise `CommunicationError("Stellantis rejected the access token (HTTP 401)")` instead of the raw server text.
  - `ConfigEntryAuthFailed` from a dead refresh token still propagates, so reauth triggers normally.
  - `refresh_oauth_token_request` is already `@rate_limit(6, 1800)`, so the retry can't storm the token endpoint.
- `base.py::_async_update_data`: `UpdateFailed` now points users at debug logging for the real reason, instead of a bare generic string.
- `make_http_request`: the `404`, `500`, `400`/`invalid_grant` and generic `50x` branches now fall back to a fixed, descriptive message when the response body doesn't match a known error shape, instead of raising/logging the literal string `"None"`.

**Behaviour**

| | Before | After |
|---|---|---|
| Transient 401 | one `UpdateFailed`, entities flap to `unavailable` for a cycle | silently refreshed and retried, no `UpdateFailed` |
| Persistent 401 | generic `UpdateFailed`, no pointer to the debug log | same generic `UpdateFailed`, now points at the debug log (raw server text was and remains debug-only) |
