### PR TITLE
Bound the coordinator's command history to a fixed size

### DIFF
--- a/custom_components/stellantis_vehicles/base.py
+++ b/custom_components/stellantis_vehicles/base.py
@@ -28,6 +28,7 @@ from .const import (
     VEHICLE_TYPE_HYBRID,
     UPDATE_INTERVAL,
     EMPTY_STATUS_LIMIT,
+    COMMAND_HISTORY_LIMIT,
     KWH_CORRECTION
 )
 
@@ -224,6 +225,18 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         last_action_id = list(self._commands_history.keys())[-1]
         return not self._commands_history[last_action_id]["updates"]
 
+    def _prune_command_history(self):
+        """ Drop the oldest command-history entries beyond COMMAND_HISTORY_LIMIT.
+
+        Every sent command adds an entry that would otherwise never be
+        removed, growing this dict (and the linear sort in command_history)
+        for as long as the coordinator lives.
+        """
+        excess = len(self._commands_history) - COMMAND_HISTORY_LIMIT
+        for _ in range(max(0, excess)):
+            oldest_id = next(iter(self._commands_history))
+            del self._commands_history[oldest_id]
+
     async def update_command_history(self, action_id, update = None):
         """ Update command history. """
         if action_id not in self._commands_history:
@@ -231,12 +244,15 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
         if update:
             self._commands_history[action_id]["updates"].append({"info": update, "date": get_datetime()})
             if update == "not_compatible":
-                self._disabled_commands.append(self._commands_history[action_id]["name"])
+                disabled_name = self._commands_history[action_id]["name"]
+                if disabled_name not in self._disabled_commands:
+                    self._disabled_commands.append(disabled_name)
         self.async_update_listeners()
 
     def update_command_history_rate_limit(self, name):
         current_datetime = get_datetime()
         self._commands_history.update({current_datetime.time(): {"name": name, "updates": [{"info": "rate_limit", "date": current_datetime}]}})
+        self._prune_command_history()
         self.async_update_listeners()
 
     async def send_command(self, name, service, message):
@@ -245,6 +261,7 @@ class StellantisVehicleCoordinator(DataUpdateCoordinator):
             action_id = await self._stellantis.send_mqtt_message(service, message, self._vehicle)
             if action_id is not None:
                 self._commands_history.update({action_id: {"name": name, "updates": []}})
+                self._prune_command_history()
                 self.async_update_listeners()
         except ConfigEntryAuthFailed as e:
             _LOGGER.warning("Authentication failed while sending command '%s' to vehicle '%s': %s", name, self._vehicle['vin'], str(e))

--- a/custom_components/stellantis_vehicles/const.py
+++ b/custom_components/stellantis_vehicles/const.py
@@ -131,6 +131,11 @@ UPDATE_INTERVAL = 60 # seconds
 # re-fetched to check whether the vehicle was unpaired.
 EMPTY_STATUS_LIMIT = 3
 
+# Maximum number of entries kept in a coordinator's command history. Without a
+# cap, every sent command would stay in memory (and be re-sorted on every
+# coordinator update) for as long as the coordinator lives.
+COMMAND_HISTORY_LIMIT = 50
+
 # Backoff schedule (seconds) for the MQTT token refresh after a transient
 # Stellantis backend failure. Capped at the last step so a prolonged outage is
 # retried every ~15 min instead of once a minute.


### PR DESCRIPTION
## Summary

`StellantisVehicleCoordinator._commands_history` records one entry per sent command (button press, wakeup, charge, preconditioning, ...), plus one appended "update" per MQTT response for that command. Nothing ever removed an old entry, so the dict grew for as long as the coordinator lived (until Home Assistant restarted or the integration entry was reloaded).

Two related effects came from this:

- Unbounded memory growth on long-running installations, proportional to the total number of commands ever sent, not to how many are actually relevant (only the most recent one is shown as the `command_status` sensor's state).
- `command_history` (the property that builds the sensor's displayed value) rebuilds and sorts a list from every entry on every coordinator update, so its cost also grows without bound over the coordinator's lifetime.

Separately, `_disabled_commands` (the list of command names a vehicle reported as not supported) appended the same name again on every `not_compatible` response for that command, so a command an automation keeps retrying accumulated duplicate entries indefinitely.

## Change

`const.py`: new `COMMAND_HISTORY_LIMIT = 50`.

`base.py`, `StellantisVehicleCoordinator`:

- `_prune_command_history()`: drops the oldest entries from `_commands_history` once it exceeds `COMMAND_HISTORY_LIMIT`. Dict insertion order is relied on to identify the oldest entries, which holds here since entries are only ever added, never reordered.
- Called after the two places that add a new top-level entry: `send_command()` and `update_command_history_rate_limit()`.
- `update_command_history()`: only appends to `_disabled_commands` when the command's name is not already in it, instead of unconditionally.

## Behaviour

| | Before | After |
|---|---|---|
| Long-running process, commands sent over weeks/months | `_commands_history` grows without bound, `command_history` sort cost rises with it | capped at `COMMAND_HISTORY_LIMIT` (50) entries, constant cost |
| A command repeatedly reported as `not_compatible` | `_disabled_commands` gains a duplicate on every occurrence | name recorded once |
| `command_status` sensor / `pending_action` | unaffected (both only ever look at the most recent entry) | unaffected |

## Scope and non-goals

- No change to which commands are available, to entity states, or to config entry data.
- `COMMAND_HISTORY_LIMIT` is fixed, not user-configurable (no new option), matching how other internal limits in this file (e.g. `EMPTY_STATUS_LIMIT`) are handled.
- If an MQTT response for a command arrives after that command's entry has already been pruned (only possible once 50 newer commands were sent to the same vehicle in the meantime), `update_command_history()` silently no-ops via its existing `action_id not in self._commands_history` guard - the same fallback path already used for any other unknown `action_id`.

## Manual verification and testing

- [x] Send more than 50 commands to a vehicle (e.g. repeated wakeup/lock/unlock via automation or the dashboard) and confirm `_commands_history` never exceeds 50 entries (e.g. via `profiler.dump_log_objects` with `type: StellantisVehicleCoordinator`, or by adding a temporary debug log of `len(self._commands_history)`).
- [x] Confirm the `command_status` sensor still reflects the most recent command's status after pruning has occurred.

